### PR TITLE
Install v0.16.0 by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@
   DESTINATION="${PREFIX:-/usr/local/bin}/toast"
 
   # Which version to download
-  RELEASE="v${VERSION:-0.15.0}"
+  RELEASE="v${VERSION:-0.16.0}"
 
   # Determine which binary to download.
   FILENAME=''


### PR DESCRIPTION
Install v0.16.0 by default. I meant to do this in https://github.com/stepchowfun/toast/pull/183.