### PR TITLE
Add a checksum verification step to the installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,52 +5,79 @@
 #   VERSION=x.y.z ./install.sh
 #   PREFIX=/usr/local/bin ./install.sh
 
-# We wrap everything in curly braces to prevent the shell from executing only
-# a prefix of the script if the download is interrupted.
-{
+# We wrap everything in parentheses for two reasons:
+# 1. To prevent the shell from executing only a prefix of the script if the
+#    download is interrupted
+# 2. To ensure that any working directory changes with `cd` are local to this
+#    script and don't affect the calling user's shell
+(
   # Where the binary will be installed
   DESTINATION="${PREFIX:-/usr/local/bin}/toast"
 
   # Which version to download
-  RELEASE="v${VERSION:-0.16.0}"
+  RELEASE="v${VERSION:-0.17.0}"
 
   # Determine which binary to download.
   FILENAME=''
+  CHECKSUM=''
   if uname -a | grep -qi 'x86_64.*GNU/Linux'; then
     echo 'x86_64 GNU/Linux detected.'
     FILENAME=toast-x86_64-unknown-linux-gnu
+    CHECKSUM='e60b17ae29adb623d29da5511bc60c32eabb64a25324fe2c29bba8f0db36c7ff'
   fi
   if uname -a | grep -qi 'Darwin.*x86_64'; then
     echo 'macOS detected.'
     FILENAME=toast-x86_64-apple-darwin
-  fi
-
-  # Fail if there is no pre-built binary for this platform.
-  if [ -z "$FILENAME" ]; then
-    echo 'Unfortunately, there is no pre-built binary for this platform.' 1>&2
-    exit 1
+    CHECKSUM='2ed56f6c48d7a28b5fbcf58fc6765efb9f502baae42e4ac4863d09d3367eab1a'
   fi
 
   # Find a temporary location for the binary.
-  TEMPFILE=$(mktemp /tmp/toast.XXXXXXXX)
+  TEMPDIR=$(mktemp -d /tmp/toast.XXXXXXXX)
+
+  # This is a helper function to clean up and fail.
+  fail() {
+    echo "$1" >&2
+    cd "$TEMPDIR/.." || exit 1
+    rm -rf "$TEMPDIR"
+    exit 1
+  }
+
+  # Enter the temporary directory.
+  cd "$TEMPDIR" || fail "Unable to access the temporary directory $TEMPDIR."
+
+  # Fail if there is no pre-built binary for this platform.
+  if [ -z "$FILENAME" ]; then
+    fail 'Unfortunately, there is no pre-built binary for this platform.'
+  fi
 
   # Download the binary.
-  if ! curl "https://github.com/stepchowfun/toast/releases/download/$RELEASE/$FILENAME" -o "$TEMPFILE" -LSf; then
-    echo 'There was an error downloading the binary.' 1>&2
-    rm "$TEMPFILE"
-    exit 1
+  if ! curl "https://github.com/stepchowfun/toast/releases/download/$RELEASE/$FILENAME" -o "$FILENAME" -LSf; then
+    fail 'There was an error downloading the binary.'
+  fi
+
+  # Download the checksum.
+  if ! curl "https://github.com/stepchowfun/toast/releases/download/$RELEASE/$FILENAME.sha256" -o "$FILENAME.sha256" -LSf; then
+    fail 'There was an error downloading the checksum.'
+  fi
+
+  # Verify the checksum.
+  if ! echo "$CHECKSUM *$FILENAME" | sha256sum --check --strict --quiet --status; then
+    fail 'The downloaded binary was corrupted. Feel free to try again.'
   fi
 
   # Make it executable.
-  if ! chmod a+rx "$TEMPFILE"; then
-    echo 'There was an error setting the permissions for the binary.' 1>&2
-    rm "$TEMPFILE"
-    exit 1
+  if ! chmod a+rx "$FILENAME"; then
+    fail 'There was an error setting the permissions for the binary.'
   fi
 
   # Install it at the requested destination.
-  mv "$TEMPFILE" "$DESTINATION" 2> /dev/null || sudo mv "$TEMPFILE" "$DESTINATION" < /dev/tty
+  # shellcheck disable=SC2024
+  mv "$FILENAME" "$DESTINATION" 2> /dev/null || sudo mv "$FILENAME" "$DESTINATION" < /dev/tty || fail "Unable to install the binary at $DESTINATION."
+
+  # Remove the temporary directory.
+  cd ..
+  rm -rf "$TEMPDIR"
 
   # Let the user know it worked.
-  echo 'Toast is now installed.'
-}
+  echo "$("$DESTINATION" --version) is now installed."
+)

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -11,6 +11,7 @@ echo "Toast location: $TOAST"
 docker --version
 
 # Run the integration tests.
+# shellcheck disable=SC2045
 for TEST in $(ls integration-tests); do
   # Log which integration test we're about to run.
   echo "Running integration test: $TEST"
@@ -18,6 +19,7 @@ for TEST in $(ls integration-tests); do
   # Stop all running Docker containers.
   CONTAINERS="$(docker ps --no-trunc --quiet)"
   if [ -n "$CONTAINERS" ]; then
+    # shellcheck disable=SC2086
     docker container stop $CONTAINERS > /dev/null
   fi
 

--- a/integration-tests/alpine/run.sh
+++ b/integration-tests/alpine/run.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 "$TOAST"
-cat output.txt | grep 'Hello'
+grep 'Hello' output.txt
 rm output.txt

--- a/integration-tests/busybox/run.sh
+++ b/integration-tests/busybox/run.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 "$TOAST"
-cat output.txt | grep 'Hello'
+grep 'Hello' output.txt
 rm output.txt

--- a/integration-tests/centos/run.sh
+++ b/integration-tests/centos/run.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 "$TOAST"
-cat output.txt | grep 'Hello'
+grep 'Hello' output.txt
 rm output.txt

--- a/integration-tests/debian/run.sh
+++ b/integration-tests/debian/run.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 "$TOAST"
-cat output.txt | grep 'Hello'
+grep 'Hello' output.txt
 rm output.txt

--- a/integration-tests/fedora/run.sh
+++ b/integration-tests/fedora/run.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 "$TOAST"
-cat output.txt | grep 'Hello'
+grep 'Hello' output.txt
 rm output.txt

--- a/integration-tests/ubuntu/run.sh
+++ b/integration-tests/ubuntu/run.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 "$TOAST"
-cat output.txt | grep 'Hello'
+grep 'Hello' output.txt
 rm output.txt

--- a/toast.yml
+++ b/toast.yml
@@ -5,7 +5,7 @@ tasks:
     command: |
       set -euo pipefail
       apt-get update
-      apt-get install --yes build-essential curl
+      apt-get install --yes build-essential curl shellcheck
 
   install_tagref:
     dependencies:
@@ -84,6 +84,9 @@ tasks:
       - build
     input_paths:
       - .ignore # Used by `tagref`
+      - install.sh # Linted by ShellCheck
+      - integration-tests # Linted by ShellCheck
+      - integration-tests.sh # Linted by ShellCheck
       - rustfmt.toml # Used by `cargo fmt`
     user: user
     command: |
@@ -92,6 +95,9 @@ tasks:
       cargo clippy --all-targets --all-features -- --deny warnings --deny clippy::all --deny clippy::pedantic
       cargo fmt --all -- --check
       tagref
+      shellcheck install.sh
+      shellcheck integration-tests.sh
+      shellcheck integration-tests/**/*.sh
 
   build-test-lint:
     dependencies:
@@ -112,4 +118,5 @@ tasks:
       . $HOME/.cargo/env
       cargo build --release
       mkdir artifacts
+      sha256sum --binary target/release/toast
       cp target/release/toast artifacts/toast-x86_64-unknown-linux-gnu


### PR DESCRIPTION
Add a checksum verification step to the installation script. This will ensure that the downloaded binary is not corrupted.

@juliahw