### PR TITLE
Fix a bug that would cause images to be far larger than necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2019-05-22
+
+### Fixed
+- Fixed a bug that would cause images to be far larger than necessary.
+
 ## [0.17.0] - 2019-05-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 description = "A containerized build system."
 license = "MIT"


### PR DESCRIPTION
Fix a bug that would cause images to be far larger than necessary. The bug was caused by the fact that if you (a) change some files in a container, (b) do `docker container commit`, then (c) change some more files, and finally (d) run `docker container commit` again, the layer added by (b) will not be shared by the image produced by (d). The second image will have a layer that has the combined changes of (a) and (c).