### PR TITLE
Use 4 spaces instead of 2 and wordsmith the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 *Toast* is a tool for running tasks in containers. You define tasks in a *toastfile*, and Toast runs them in an environment based on a Docker image of your choosing. Tasks can depend on other tasks, which makes Toast similar to a build system. What constitutes a "task" is up to you: tasks can install system packages, build an application, run a test suite, serve web pages, deploy a service, etc.
 
-Toast supports local and remote caching to avoid repeating work. Toast records a diff of the entire filesystem after each task by committing the container to an image. Each image is tagged with a cache key that incorporates the shell command for the task, the contents of the files copied into the container, and all the other inputs. If remote caching is enabled, Toast will upload the images to a Docker registry to be used by other machines.
+Toast supports local and remote caching to avoid repeating work. Toast records a diff of the entire filesystem after each task by committing the container to an image. Each image is tagged with a cache key that incorporates the shell command for the task, the contents of the files copied into the container, and all the other task inputs. If remote caching is enabled, Toast will upload the images to a Docker registry to be used by other machines.
 
 ![Welcome to Toast.](https://raw.githubusercontent.com/stepchowfun/toast/master/media/welcome-0.svg?sanitize=true)
 
-The tutorial below aims to demonstrate how Toast can simplify your development workflow. On the other hand, here are two situations for which Toast is not suitable:
+The tutorial below aims to demonstrate how Toast can simplify your development workflow. On the other hand, here are two situations for which Toast is *not* suitable:
 
 - Tasks that cannot run in Linux containers: for example, you wouldn't use Toast to build an iOS application.
 - Multi-container applications: you can use a tool like [Docker Compose](https://docs.docker.com/compose/overview/) to do that, but you will forgo some toasty benefits like remote caching, filesystem watching, and the ability to define tasks and dependencies.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
 max_width = 79
 hard_tabs = false
-tab_spaces = 2
+tab_spaces = 4

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -5,485 +5,485 @@ use std::{collections::HashMap, io, io::Read};
 // Determine the cache ID of a task based on the cache ID of the previous task
 // in the schedule (or the hash of the base image, if this is the first task).
 pub fn key(
-  previous_key: &str,
-  task: &Task,
-  input_files_hash: &str,
-  environment: &HashMap<String, String>,
+    previous_key: &str,
+    task: &Task,
+    input_files_hash: &str,
+    environment: &HashMap<String, String>,
 ) -> String {
-  // Start with the previous key.
-  let mut cache_key = previous_key.to_owned();
+    // Start with the previous key.
+    let mut cache_key = previous_key.to_owned();
 
-  // If there are no input paths and no command to run, we can just use the
-  // cache key from the previous task.
-  if task.input_paths.is_empty() && task.command.is_none() {
-    return cache_key;
-  }
+    // If there are no input paths and no command to run, we can just use the
+    // cache key from the previous task.
+    if task.input_paths.is_empty() && task.command.is_none() {
+        return cache_key;
+    }
 
-  // Environment variables
-  let mut variables = task.environment.keys().collect::<Vec<_>>();
-  variables.sort();
-  for variable in variables {
-    cache_key = extend(&cache_key, variable);
-    cache_key = extend(&cache_key, &environment[variable]); // [ref:environment_valid]
-  }
+    // Environment variables
+    let mut variables = task.environment.keys().collect::<Vec<_>>();
+    variables.sort();
+    for variable in variables {
+        cache_key = extend(&cache_key, variable);
+        cache_key = extend(&cache_key, &environment[variable]); // [ref:environment_valid]
+    }
 
-  // Input paths and contents
-  cache_key = extend(&cache_key, &input_files_hash);
+    // Input paths and contents
+    cache_key = extend(&cache_key, &input_files_hash);
 
-  // Location
-  cache_key = extend(&cache_key, &task.location.to_string_lossy());
+    // Location
+    cache_key = extend(&cache_key, &task.location.to_string_lossy());
 
-  // User
-  cache_key = extend(&cache_key, &task.user);
+    // User
+    cache_key = extend(&cache_key, &task.user);
 
-  // Command
-  if let Some(command) = &task.command {
-    cache_key = extend(&cache_key, &command);
-  }
+    // Command
+    if let Some(command) = &task.command {
+        cache_key = extend(&cache_key, &command);
+    }
 
-  // We add this "toast-" prefix because Docker has a rule that tags cannot be
-  // 64-byte hexadecimal strings. See this for more details:
-  //   https://github.com/moby/moby/issues/20972
-  format!("toast-{}", cache_key)
+    // We add this "toast-" prefix because Docker has a rule that tags cannot be
+    // 64-byte hexadecimal strings. See this for more details:
+    //   https://github.com/moby/moby/issues/20972
+    format!("toast-{}", cache_key)
 }
 
 // Compute the hash of a readable object (e.g., a file). This function does not
 // need to load all the data in memory at the same time.
 pub fn hash_read<R: Read>(input: &mut R) -> Result<String, String> {
-  let mut hasher = Sha256::new();
-  io::copy(input, &mut hasher)
-    .map_err(|e| format!("Unable to compute hash. Details: {}.", e))?;
-  Ok(hex::encode(hasher.result()))
+    let mut hasher = Sha256::new();
+    io::copy(input, &mut hasher)
+        .map_err(|e| format!("Unable to compute hash. Details: {}.", e))?;
+    Ok(hex::encode(hasher.result()))
 }
 
 // Compute the hash of a string.
 pub fn hash_str(input: &str) -> String {
-  hex::encode(Sha256::digest(input.as_bytes()))
+    hex::encode(Sha256::digest(input.as_bytes()))
 }
 
 // Combine a hash with another string to form a new hash.
 pub fn extend(x: &str, y: &str) -> String {
-  hash_str(&format!("{}{}", x, y))
+    hash_str(&format!("{}{}", x, y))
 }
 
 #[cfg(test)]
 mod tests {
-  use crate::{
-    cache::{extend, hash_read, hash_str, key},
-    toastfile::{Task, DEFAULT_LOCATION, DEFAULT_USER},
-  };
-  use std::{collections::HashMap, path::Path};
-
-  #[test]
-  fn key_pure() {
-    let mut environment: HashMap<String, Option<String>> = HashMap::new();
-    environment.insert("foo".to_owned(), None);
-
-    let previous_key = "corge";
-
-    let task = Task {
-      dependencies: vec![],
-      cache: true,
-      environment,
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo wibble".to_owned()),
+    use crate::{
+        cache::{extend, hash_read, hash_str, key},
+        toastfile::{Task, DEFAULT_LOCATION, DEFAULT_USER},
     };
-
-    let input_files_hash = "grault";
-
-    let mut full_environment = HashMap::new();
-    full_environment.insert("foo".to_owned(), "qux".to_owned());
-
-    assert_eq!(
-      key(previous_key, &task, input_files_hash, &full_environment),
-      key(previous_key, &task, input_files_hash, &full_environment)
-    );
-  }
-
-  #[test]
-  fn key_previous_key() {
-    let previous_key1 = "foo";
-    let previous_key2 = "bar";
-
-    let task = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: HashMap::new(),
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo wibble".to_owned()),
-    };
-
-    let input_files_hash = "grault";
-
-    let full_environment = HashMap::new();
-
-    assert_ne!(
-      key(previous_key1, &task, input_files_hash, &full_environment),
-      key(previous_key2, &task, input_files_hash, &full_environment)
-    );
-  }
-
-  #[test]
-  fn key_environment_order() {
-    let mut environment1: HashMap<String, Option<String>> = HashMap::new();
-    environment1.insert("foo".to_owned(), None);
-    environment1.insert("bar".to_owned(), None);
-
-    let mut environment2: HashMap<String, Option<String>> = HashMap::new();
-    environment2.insert("bar".to_owned(), None);
-    environment2.insert("foo".to_owned(), None);
-
-    let previous_key = "corge";
-
-    let task1 = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: environment1,
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo wibble".to_owned()),
-    };
-
-    let task2 = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: environment2,
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo wibble".to_owned()),
-    };
-
-    let input_files_hash = "grault";
-
-    let mut full_environment = HashMap::new();
-    full_environment.insert("foo".to_owned(), "qux".to_owned());
-    full_environment.insert("bar".to_owned(), "fum".to_owned());
-
-    assert_eq!(
-      key(previous_key, &task1, input_files_hash, &full_environment),
-      key(previous_key, &task2, input_files_hash, &full_environment)
-    );
-  }
-
-  #[test]
-  fn key_environment_keys() {
-    let mut environment1: HashMap<String, Option<String>> = HashMap::new();
-    environment1.insert("foo".to_owned(), None);
-
-    let mut environment2: HashMap<String, Option<String>> = HashMap::new();
-    environment2.insert("bar".to_owned(), None);
-
-    let previous_key = "corge";
-
-    let task1 = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: environment1,
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo wibble".to_owned()),
-    };
-
-    let task2 = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: environment2,
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo wibble".to_owned()),
-    };
-
-    let input_files_hash = "grault";
-
-    let mut full_environment = HashMap::new();
-    full_environment.insert("foo".to_owned(), "qux".to_owned());
-    full_environment.insert("bar".to_owned(), "fum".to_owned());
-
-    assert_ne!(
-      key(previous_key, &task1, input_files_hash, &full_environment),
-      key(previous_key, &task2, input_files_hash, &full_environment)
-    );
-  }
-
-  #[test]
-  fn key_environment_values() {
-    let mut environment: HashMap<String, Option<String>> = HashMap::new();
-    environment.insert("foo".to_owned(), None);
-
-    let previous_key = "corge";
-
-    let task = Task {
-      dependencies: vec![],
-      cache: true,
-      environment,
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo wibble".to_owned()),
-    };
-
-    let input_files_hash = "grault";
-
-    let mut full_environment1 = HashMap::new();
-    full_environment1.insert("foo".to_owned(), "bar".to_owned());
-    let mut full_environment2 = HashMap::new();
-    full_environment2.insert("foo".to_owned(), "baz".to_owned());
-
-    assert_ne!(
-      key(previous_key, &task, input_files_hash, &full_environment1),
-      key(previous_key, &task, input_files_hash, &full_environment2)
-    );
-  }
-
-  #[test]
-  fn key_input_files_hash() {
-    let previous_key = "corge";
-
-    let task = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: HashMap::new(),
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo wibble".to_owned()),
-    };
-
-    let input_files_hash1 = "foo";
-    let input_files_hash2 = "bar";
-
-    let full_environment = HashMap::new();
-
-    assert_ne!(
-      key(previous_key, &task, input_files_hash1, &full_environment),
-      key(previous_key, &task, input_files_hash2, &full_environment)
-    );
-  }
-
-  #[test]
-  fn key_location() {
-    let previous_key = "corge";
-
-    let task1 = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: HashMap::new(),
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new("/foo").to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo wibble".to_owned()),
-    };
-
-    let task2 = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: HashMap::new(),
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new("/bar").to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo wibble".to_owned()),
-    };
-
-    let input_files_hash = "grault";
-
-    let full_environment = HashMap::new();
-
-    assert_ne!(
-      key(previous_key, &task1, input_files_hash, &full_environment),
-      key(previous_key, &task2, input_files_hash, &full_environment)
-    );
-  }
-
-  #[test]
-  fn key_user() {
-    let previous_key = "corge";
-
-    let task1 = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: HashMap::new(),
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: "foo".to_owned(),
-      command: Some("echo wibble".to_owned()),
-    };
-
-    let task2 = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: HashMap::new(),
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: "bar".to_owned(),
-      command: Some("echo wibble".to_owned()),
-    };
-
-    let input_files_hash = "grault";
-
-    let full_environment = HashMap::new();
-
-    assert_ne!(
-      key(previous_key, &task1, input_files_hash, &full_environment),
-      key(previous_key, &task2, input_files_hash, &full_environment)
-    );
-  }
-
-  #[test]
-  fn key_command_different() {
-    let previous_key = "corge";
-
-    let task1 = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: HashMap::new(),
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo foo".to_owned()),
-    };
-
-    let task2 = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: HashMap::new(),
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo bar".to_owned()),
-    };
-
-    let input_files_hash = "grault";
-
-    let full_environment = HashMap::new();
-
-    assert_ne!(
-      key(previous_key, &task1, input_files_hash, &full_environment),
-      key(previous_key, &task2, input_files_hash, &full_environment)
-    );
-  }
-
-  #[test]
-  fn key_command_some_none() {
-    let previous_key = "corge";
-
-    let task1 = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: HashMap::new(),
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: Some("echo wibble".to_owned()),
-    };
-
-    let task2 = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: HashMap::new(),
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: None,
-    };
-
-    let input_files_hash = "grault";
-
-    let full_environment = HashMap::new();
-
-    assert_ne!(
-      key(previous_key, &task1, input_files_hash, &full_environment),
-      key(previous_key, &task2, input_files_hash, &full_environment)
-    )
-  }
-
-  #[test]
-  fn hash_read_pure() {
-    let mut str1 = b"foo" as &[u8];
-    let mut str2 = b"foo" as &[u8];
-    assert_eq!(hash_read(&mut str1), hash_read(&mut str2));
-  }
-
-  #[test]
-  fn hash_read_not_constant() {
-    let mut str1 = b"foo" as &[u8];
-    let mut str2 = b"bar" as &[u8];
-    assert_ne!(hash_read(&mut str1), hash_read(&mut str2));
-  }
-
-  #[test]
-  fn hash_str_pure() {
-    assert_eq!(hash_str("foo"), hash_str("foo"));
-  }
-
-  #[test]
-  fn hash_str_not_constant() {
-    assert_ne!(hash_str("foo"), hash_str("bar"));
-  }
-
-  #[test]
-  fn extend_pure() {
-    assert_eq!(extend("foo", "bar"), extend("foo", "bar"));
-  }
-
-  #[test]
-  fn extend_not_constant() {
-    assert_ne!(extend("foo", "bar"), extend("foo", "baz"));
-    assert_ne!(extend("foo", "bar"), extend("baz", "bar"));
-  }
+    use std::{collections::HashMap, path::Path};
+
+    #[test]
+    fn key_pure() {
+        let mut environment: HashMap<String, Option<String>> = HashMap::new();
+        environment.insert("foo".to_owned(), None);
+
+        let previous_key = "corge";
+
+        let task = Task {
+            dependencies: vec![],
+            cache: true,
+            environment,
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let input_files_hash = "grault";
+
+        let mut full_environment = HashMap::new();
+        full_environment.insert("foo".to_owned(), "qux".to_owned());
+
+        assert_eq!(
+            key(previous_key, &task, input_files_hash, &full_environment),
+            key(previous_key, &task, input_files_hash, &full_environment)
+        );
+    }
+
+    #[test]
+    fn key_previous_key() {
+        let previous_key1 = "foo";
+        let previous_key2 = "bar";
+
+        let task = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: HashMap::new(),
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let input_files_hash = "grault";
+
+        let full_environment = HashMap::new();
+
+        assert_ne!(
+            key(previous_key1, &task, input_files_hash, &full_environment),
+            key(previous_key2, &task, input_files_hash, &full_environment)
+        );
+    }
+
+    #[test]
+    fn key_environment_order() {
+        let mut environment1: HashMap<String, Option<String>> = HashMap::new();
+        environment1.insert("foo".to_owned(), None);
+        environment1.insert("bar".to_owned(), None);
+
+        let mut environment2: HashMap<String, Option<String>> = HashMap::new();
+        environment2.insert("bar".to_owned(), None);
+        environment2.insert("foo".to_owned(), None);
+
+        let previous_key = "corge";
+
+        let task1 = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: environment1,
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let task2 = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: environment2,
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let input_files_hash = "grault";
+
+        let mut full_environment = HashMap::new();
+        full_environment.insert("foo".to_owned(), "qux".to_owned());
+        full_environment.insert("bar".to_owned(), "fum".to_owned());
+
+        assert_eq!(
+            key(previous_key, &task1, input_files_hash, &full_environment),
+            key(previous_key, &task2, input_files_hash, &full_environment)
+        );
+    }
+
+    #[test]
+    fn key_environment_keys() {
+        let mut environment1: HashMap<String, Option<String>> = HashMap::new();
+        environment1.insert("foo".to_owned(), None);
+
+        let mut environment2: HashMap<String, Option<String>> = HashMap::new();
+        environment2.insert("bar".to_owned(), None);
+
+        let previous_key = "corge";
+
+        let task1 = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: environment1,
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let task2 = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: environment2,
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let input_files_hash = "grault";
+
+        let mut full_environment = HashMap::new();
+        full_environment.insert("foo".to_owned(), "qux".to_owned());
+        full_environment.insert("bar".to_owned(), "fum".to_owned());
+
+        assert_ne!(
+            key(previous_key, &task1, input_files_hash, &full_environment),
+            key(previous_key, &task2, input_files_hash, &full_environment)
+        );
+    }
+
+    #[test]
+    fn key_environment_values() {
+        let mut environment: HashMap<String, Option<String>> = HashMap::new();
+        environment.insert("foo".to_owned(), None);
+
+        let previous_key = "corge";
+
+        let task = Task {
+            dependencies: vec![],
+            cache: true,
+            environment,
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let input_files_hash = "grault";
+
+        let mut full_environment1 = HashMap::new();
+        full_environment1.insert("foo".to_owned(), "bar".to_owned());
+        let mut full_environment2 = HashMap::new();
+        full_environment2.insert("foo".to_owned(), "baz".to_owned());
+
+        assert_ne!(
+            key(previous_key, &task, input_files_hash, &full_environment1),
+            key(previous_key, &task, input_files_hash, &full_environment2)
+        );
+    }
+
+    #[test]
+    fn key_input_files_hash() {
+        let previous_key = "corge";
+
+        let task = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: HashMap::new(),
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let input_files_hash1 = "foo";
+        let input_files_hash2 = "bar";
+
+        let full_environment = HashMap::new();
+
+        assert_ne!(
+            key(previous_key, &task, input_files_hash1, &full_environment),
+            key(previous_key, &task, input_files_hash2, &full_environment)
+        );
+    }
+
+    #[test]
+    fn key_location() {
+        let previous_key = "corge";
+
+        let task1 = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: HashMap::new(),
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new("/foo").to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let task2 = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: HashMap::new(),
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new("/bar").to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let input_files_hash = "grault";
+
+        let full_environment = HashMap::new();
+
+        assert_ne!(
+            key(previous_key, &task1, input_files_hash, &full_environment),
+            key(previous_key, &task2, input_files_hash, &full_environment)
+        );
+    }
+
+    #[test]
+    fn key_user() {
+        let previous_key = "corge";
+
+        let task1 = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: HashMap::new(),
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: "foo".to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let task2 = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: HashMap::new(),
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: "bar".to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let input_files_hash = "grault";
+
+        let full_environment = HashMap::new();
+
+        assert_ne!(
+            key(previous_key, &task1, input_files_hash, &full_environment),
+            key(previous_key, &task2, input_files_hash, &full_environment)
+        );
+    }
+
+    #[test]
+    fn key_command_different() {
+        let previous_key = "corge";
+
+        let task1 = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: HashMap::new(),
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo foo".to_owned()),
+        };
+
+        let task2 = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: HashMap::new(),
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo bar".to_owned()),
+        };
+
+        let input_files_hash = "grault";
+
+        let full_environment = HashMap::new();
+
+        assert_ne!(
+            key(previous_key, &task1, input_files_hash, &full_environment),
+            key(previous_key, &task2, input_files_hash, &full_environment)
+        );
+    }
+
+    #[test]
+    fn key_command_some_none() {
+        let previous_key = "corge";
+
+        let task1 = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: HashMap::new(),
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: Some("echo wibble".to_owned()),
+        };
+
+        let task2 = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: HashMap::new(),
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: None,
+        };
+
+        let input_files_hash = "grault";
+
+        let full_environment = HashMap::new();
+
+        assert_ne!(
+            key(previous_key, &task1, input_files_hash, &full_environment),
+            key(previous_key, &task2, input_files_hash, &full_environment)
+        )
+    }
+
+    #[test]
+    fn hash_read_pure() {
+        let mut str1 = b"foo" as &[u8];
+        let mut str2 = b"foo" as &[u8];
+        assert_eq!(hash_read(&mut str1), hash_read(&mut str2));
+    }
+
+    #[test]
+    fn hash_read_not_constant() {
+        let mut str1 = b"foo" as &[u8];
+        let mut str2 = b"bar" as &[u8];
+        assert_ne!(hash_read(&mut str1), hash_read(&mut str2));
+    }
+
+    #[test]
+    fn hash_str_pure() {
+        assert_eq!(hash_str("foo"), hash_str("foo"));
+    }
+
+    #[test]
+    fn hash_str_not_constant() {
+        assert_ne!(hash_str("foo"), hash_str("bar"));
+    }
+
+    #[test]
+    fn extend_pure() {
+        assert_eq!(extend("foo", "bar"), extend("foo", "bar"));
+    }
+
+    #[test]
+    fn extend_not_constant() {
+        assert_ne!(extend("foo", "bar"), extend("foo", "baz"));
+        assert_ne!(extend("foo", "bar"), extend("baz", "bar"));
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,83 +7,83 @@ pub const EMPTY_CONFIG: &str = "{}";
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
-  #[serde(default = "default_docker_repo")]
-  pub docker_repo: String,
+    #[serde(default = "default_docker_repo")]
+    pub docker_repo: String,
 
-  #[serde(default = "default_read_local_cache")]
-  pub read_local_cache: bool,
+    #[serde(default = "default_read_local_cache")]
+    pub read_local_cache: bool,
 
-  #[serde(default = "default_write_local_cache")]
-  pub write_local_cache: bool,
+    #[serde(default = "default_write_local_cache")]
+    pub write_local_cache: bool,
 
-  #[serde(default = "default_read_remote_cache")]
-  pub read_remote_cache: bool,
+    #[serde(default = "default_read_remote_cache")]
+    pub read_remote_cache: bool,
 
-  #[serde(default = "default_write_remote_cache")]
-  pub write_remote_cache: bool,
+    #[serde(default = "default_write_remote_cache")]
+    pub write_remote_cache: bool,
 }
 
 fn default_docker_repo() -> String {
-  REPO_DEFAULT.to_owned()
+    REPO_DEFAULT.to_owned()
 }
 
 fn default_read_local_cache() -> bool {
-  true
+    true
 }
 
 fn default_write_local_cache() -> bool {
-  true
+    true
 }
 
 fn default_read_remote_cache() -> bool {
-  false
+    false
 }
 
 fn default_write_remote_cache() -> bool {
-  false
+    false
 }
 
 // Parse a program configuration.
 pub fn parse(config: &str) -> Result<Config, String> {
-  serde_yaml::from_str(config).map_err(|e| format!("{}", e))
+    serde_yaml::from_str(config).map_err(|e| format!("{}", e))
 }
 
 #[cfg(test)]
 mod tests {
-  use crate::config::{parse, Config, EMPTY_CONFIG};
+    use crate::config::{parse, Config, EMPTY_CONFIG};
 
-  #[test]
-  fn parse_empty() {
-    let result = Ok(Config {
-      docker_repo: "toast".to_owned(),
-      read_local_cache: true,
-      write_local_cache: true,
-      read_remote_cache: false,
-      write_remote_cache: false,
-    });
+    #[test]
+    fn parse_empty() {
+        let result = Ok(Config {
+            docker_repo: "toast".to_owned(),
+            read_local_cache: true,
+            write_local_cache: true,
+            read_remote_cache: false,
+            write_remote_cache: false,
+        });
 
-    assert_eq!(parse(EMPTY_CONFIG), result);
-  }
+        assert_eq!(parse(EMPTY_CONFIG), result);
+    }
 
-  #[test]
-  fn parse_nonempty() {
-    let config = r#"
+    #[test]
+    fn parse_nonempty() {
+        let config = r#"
 docker_repo: foo
 read_local_cache: false
 write_local_cache: false
 read_remote_cache: true
 write_remote_cache: true
     "#
-    .trim();
+        .trim();
 
-    let result = Ok(Config {
-      docker_repo: "foo".to_owned(),
-      read_local_cache: false,
-      write_local_cache: false,
-      read_remote_cache: true,
-      write_remote_cache: true,
-    });
+        let result = Ok(Config {
+            docker_repo: "foo".to_owned(),
+            read_local_cache: false,
+            write_local_cache: false,
+            read_remote_cache: true,
+            write_remote_cache: true,
+        });
 
-    assert_eq!(parse(config), result);
-  }
+        assert_eq!(parse(config), result);
+    }
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,15 +1,15 @@
 use crate::{format::CodeStr, spinner::spin};
 use std::{
-  fs::{create_dir_all, metadata, rename},
-  io,
-  io::{Read, Write},
-  path::{Path, PathBuf},
-  process::{ChildStdin, Command, Stdio},
-  string::ToString,
-  sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-  },
+    fs::{create_dir_all, metadata, rename},
+    io,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    process::{ChildStdin, Command, Stdio},
+    string::ToString,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 use tempfile::tempdir;
 use uuid::Uuid;
@@ -17,534 +17,531 @@ use walkdir::WalkDir;
 
 // Construct a random image tag.
 pub fn random_tag() -> String {
-  Uuid::new_v4()
-    .to_simple()
-    .encode_lower(&mut Uuid::encode_buffer())
-    .to_owned()
+    Uuid::new_v4()
+        .to_simple()
+        .encode_lower(&mut Uuid::encode_buffer())
+        .to_owned()
 }
 
 // Query whether an image exists locally.
 pub fn image_exists(
-  image: &str,
-  interrupted: &Arc<AtomicBool>,
+    image: &str,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<bool, String> {
-  debug!("Checking existence of image {}\u{2026}", image.code_str());
-  if let Err(e) = run_quiet(
-    "Checking existence of image\u{2026}",
-    "The image doesn't exist.",
-    &["image", "inspect", image],
-    interrupted,
-  ) {
-    if interrupted.load(Ordering::SeqCst) {
-      Err(e)
+    debug!("Checking existence of image {}\u{2026}", image.code_str());
+    if let Err(e) = run_quiet(
+        "Checking existence of image\u{2026}",
+        "The image doesn't exist.",
+        &["image", "inspect", image],
+        interrupted,
+    ) {
+        if interrupted.load(Ordering::SeqCst) {
+            Err(e)
+        } else {
+            Ok(false)
+        }
     } else {
-      Ok(false)
+        Ok(true)
     }
-  } else {
-    Ok(true)
-  }
 }
 
 // Push an image.
 pub fn push_image(
-  image: &str,
-  interrupted: &Arc<AtomicBool>,
+    image: &str,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-  debug!("Pushing image {}\u{2026}", image.code_str());
-  run_quiet(
-    "Pushing image\u{2026}",
-    "Unable to push image.",
-    &["image", "push", image],
-    interrupted,
-  )
-  .map(|_| ())
+    debug!("Pushing image {}\u{2026}", image.code_str());
+    run_quiet(
+        "Pushing image\u{2026}",
+        "Unable to push image.",
+        &["image", "push", image],
+        interrupted,
+    )
+    .map(|_| ())
 }
 
 // Pull an image.
 pub fn pull_image(
-  image: &str,
-  interrupted: &Arc<AtomicBool>,
+    image: &str,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-  debug!("Pulling image {}\u{2026}", image.code_str());
-  run_quiet(
-    "Pulling image\u{2026}",
-    "Unable to pull image.",
-    &["image", "pull", image],
-    interrupted,
-  )
-  .map(|_| ())
+    debug!("Pulling image {}\u{2026}", image.code_str());
+    run_quiet(
+        "Pulling image\u{2026}",
+        "Unable to pull image.",
+        &["image", "pull", image],
+        interrupted,
+    )
+    .map(|_| ())
 }
 
 // Delete an image.
 pub fn delete_image(
-  image: &str,
-  interrupted: &Arc<AtomicBool>,
+    image: &str,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-  debug!("Deleting image {}\u{2026}", image.code_str());
-  run_quiet(
-    "Deleting image\u{2026}",
-    "Unable to delete image.",
-    &["image", "rm", "--force", image],
-    interrupted,
-  )
-  .map(|_| ())
+    debug!("Deleting image {}\u{2026}", image.code_str());
+    run_quiet(
+        "Deleting image\u{2026}",
+        "Unable to delete image.",
+        &["image", "rm", "--force", image],
+        interrupted,
+    )
+    .map(|_| ())
 }
 
 // Create a container and return its ID.
 pub fn create_container(
-  image: &str,
-  ports: &[String],
-  interrupted: &Arc<AtomicBool>,
+    image: &str,
+    ports: &[String],
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<String, String> {
-  debug!("Creating container from image {}\u{2026}", image.code_str(),);
+    debug!("Creating container from image {}\u{2026}", image.code_str(),);
 
-  // Why `--init`? (1) PID 1 is supposed to reap orphaned zombie processes,
-  // otherwise they can accumulate. Bash does this, but we run `/bin/sh` in the
-  // container, which may or may not be Bash. So `--init` runs Tini
-  // (https://github.com/krallin/tini) as PID 1, which properly reaps orphaned
-  // zombies. (2) PID 1 also does not exhibit the default behavior (crashing)
-  // for signals like SIGINT and SIGTERM. However, PID 1 can still handle these
-  // signals by explicitly trapping them. Tini traps these signals and forwards
-  // them to the child process. Then the default signal handling behavior of
-  // the child process (in our case, `/bin/sh`) works normally. [tag:--init]
-  let mut command = vec!["container", "create", "--init", "--interactive"];
+    // Why `--init`? (1) PID 1 is supposed to reap orphaned zombie processes,
+    // otherwise they can accumulate. Bash does this, but we run `/bin/sh` in the
+    // container, which may or may not be Bash. So `--init` runs Tini
+    // (https://github.com/krallin/tini) as PID 1, which properly reaps orphaned
+    // zombies. (2) PID 1 also does not exhibit the default behavior (crashing)
+    // for signals like SIGINT and SIGTERM. However, PID 1 can still handle these
+    // signals by explicitly trapping them. Tini traps these signals and forwards
+    // them to the child process. Then the default signal handling behavior of
+    // the child process (in our case, `/bin/sh`) works normally. [tag:--init]
+    let mut command = vec!["container", "create", "--init", "--interactive"];
 
-  for port in ports {
-    command.extend(vec!["--publish", port]);
-  }
+    for port in ports {
+        command.extend(vec!["--publish", port]);
+    }
 
-  command.extend(vec![image, "/bin/sh"]);
+    command.extend(vec![image, "/bin/sh"]);
 
-  Ok(
-    run_quiet(
-      "Creating container\u{2026}",
-      "Unable to create container.",
-      &command,
-      interrupted,
+    Ok(run_quiet(
+        "Creating container\u{2026}",
+        "Unable to create container.",
+        &command,
+        interrupted,
     )?
     .trim()
-    .to_owned(),
-  )
+    .to_owned())
 }
 
 // Copy files into a container.
 pub fn copy_into_container<R: Read>(
-  container: &str,
-  mut tar: R,
-  interrupted: &Arc<AtomicBool>,
+    container: &str,
+    mut tar: R,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-  debug!(
-    "Copying files into container {}\u{2026}",
-    container.code_str()
-  );
-  run_quiet_stdin(
-    "Copying files into container\u{2026}",
-    "Unable to copy files into the container.",
-    &["container", "cp", "-", &format!("{}:{}", container, "/")],
-    |mut stdin| {
-      io::copy(&mut tar, &mut stdin).map_err(|e| {
-        format!("Unable to copy files into the container. Details: {}.", e)
-      })?;
+    debug!(
+        "Copying files into container {}\u{2026}",
+        container.code_str()
+    );
+    run_quiet_stdin(
+        "Copying files into container\u{2026}",
+        "Unable to copy files into the container.",
+        &["container", "cp", "-", &format!("{}:{}", container, "/")],
+        |mut stdin| {
+            io::copy(&mut tar, &mut stdin).map_err(|e| {
+                format!(
+                    "Unable to copy files into the container. Details: {}.",
+                    e
+                )
+            })?;
 
-      Ok(())
-    },
-    interrupted,
-  )
-  .map(|_| ())
+            Ok(())
+        },
+        interrupted,
+    )
+    .map(|_| ())
 }
 
 // Copy files from a container.
 pub fn copy_from_container(
-  container: &str,
-  paths: &[PathBuf],
-  source_dir: &Path,
-  destination_dir: &Path,
-  interrupted: &Arc<AtomicBool>,
+    container: &str,
+    paths: &[PathBuf],
+    source_dir: &Path,
+    destination_dir: &Path,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-  // Copy each path from the container to the host.
-  for path in paths {
-    debug!(
-      "Copying {} from container {}\u{2026}",
-      path.to_string_lossy().code_str(),
-      container.code_str()
-    );
+    // Copy each path from the container to the host.
+    for path in paths {
+        debug!(
+            "Copying {} from container {}\u{2026}",
+            path.to_string_lossy().code_str(),
+            container.code_str()
+        );
 
-    // `docker container cp` is not idempotent. For example, suppose there is a
-    // directory called `/foo` in the container and `/bar` does not exist on
-    // the host. Consider the following command:
-    //   `docker cp container:/foo /bar`
-    // The first time that command is run, Docker will create the directory
-    // `/bar` on the host and copy the files from `/foo` into it. But if you
-    // run it again, Docker will copy `/bar` into the directory `/foo`,
-    // resulting in `/foo/foo`, which is undesirable. To work around this, we
-    // first copy the path from the container into a temporary directory (where
-    // the target path is guaranteed to not exist). Then we copy/move that to
-    // the final destination.
-    let temp_dir = tempdir().map_err(|e| {
-      format!("Unable to create temporary directory. Details: {}.", e)
-    })?;
+        // `docker container cp` is not idempotent. For example, suppose there is a
+        // directory called `/foo` in the container and `/bar` does not exist on
+        // the host. Consider the following command:
+        //   `docker cp container:/foo /bar`
+        // The first time that command is run, Docker will create the directory
+        // `/bar` on the host and copy the files from `/foo` into it. But if you
+        // run it again, Docker will copy `/bar` into the directory `/foo`,
+        // resulting in `/foo/foo`, which is undesirable. To work around this, we
+        // first copy the path from the container into a temporary directory (where
+        // the target path is guaranteed to not exist). Then we copy/move that to
+        // the final destination.
+        let temp_dir = tempdir().map_err(|e| {
+            format!("Unable to create temporary directory. Details: {}.", e)
+        })?;
 
-    // Figure out what needs to go where.
-    let source = source_dir.join(path);
-    let intermediate = temp_dir.path().join("data");
-    let destination = destination_dir.join(path);
+        // Figure out what needs to go where.
+        let source = source_dir.join(path);
+        let intermediate = temp_dir.path().join("data");
+        let destination = destination_dir.join(path);
 
-    // Get the path from the container.
-    run_quiet(
-      "Copying files from the container\u{2026}",
-      "Unable to copy files from the container.",
-      &[
-        "container",
-        "cp",
-        &format!("{}:{}", container, source.to_string_lossy()),
-        &intermediate.to_string_lossy(),
-      ],
-      interrupted,
-    )
-    .map(|_| ())?;
+        // Get the path from the container.
+        run_quiet(
+            "Copying files from the container\u{2026}",
+            "Unable to copy files from the container.",
+            &[
+                "container",
+                "cp",
+                &format!("{}:{}", container, source.to_string_lossy()),
+                &intermediate.to_string_lossy(),
+            ],
+            interrupted,
+        )
+        .map(|_| ())?;
 
-    // Check if what we got from the container is a file or a directory.
-    let metadata_err_map = |e| {
-      format!(
+        // Check if what we got from the container is a file or a directory.
+        let metadata_err_map = |e| {
+            format!(
         "Unable to retrieve filesystem metadata for path {}. Details: {}.",
         intermediate.to_string_lossy().code_str(),
         e
       )
-    };
-    if metadata(&intermediate).map_err(metadata_err_map)?.is_file() {
-      // It's a file. Determine the destination directory. The `unwrap` is safe
-      // because the root of the filesystem cannot be a file.
-      let destination_dir = destination.parent().unwrap().to_owned();
+        };
+        if metadata(&intermediate).map_err(metadata_err_map)?.is_file() {
+            // It's a file. Determine the destination directory. The `unwrap` is safe
+            // because the root of the filesystem cannot be a file.
+            let destination_dir = destination.parent().unwrap().to_owned();
 
-      // Make sure the destination directory exists.
-      create_dir_all(&destination_dir).map_err(|e| {
-        format!(
-          "Unable to create directory {}. Details: {}.",
-          destination_dir.to_string_lossy().code_str(),
-          e
-        )
-      })?;
+            // Make sure the destination directory exists.
+            create_dir_all(&destination_dir).map_err(|e| {
+                format!(
+                    "Unable to create directory {}. Details: {}.",
+                    destination_dir.to_string_lossy().code_str(),
+                    e
+                )
+            })?;
 
-      // Move it to the destination.
-      rename(&intermediate, &destination).map_err(|e| {
-        format!(
-          "Unable to move file {} to destination {}. Details: {}.",
-          intermediate.to_string_lossy().code_str(),
-          destination.to_string_lossy().code_str(),
-          e
-        )
-      })?;
-    } else {
-      // It's a directory. Traverse it.
-      for entry in WalkDir::new(&intermediate) {
-        // If we run into an error traversing the filesystem, report it.
-        let entry = entry.map_err(|e| {
-          format!(
-            "Unable to traverse directory {}. Details: {}.",
-            intermediate.to_string_lossy().code_str(),
-            e
-          )
-        })?;
-
-        // Figure out what needs to go where. The `unwrap` is safe because
-        // `entry` is guaranteed to be inside `intermediate` (or equal to it).
-        let entry_path = entry.path();
-        let destination_path =
-          destination.join(entry_path.strip_prefix(&intermediate).unwrap());
-
-        // Check if the current entry is a file or a directory.
-        if entry.file_type().is_dir() {
-          // It's a directory. Create a directory at the destination.
-          create_dir_all(&destination_path).map_err(|e| {
-            format!(
-              "Unable to create directory {}. Details: {}.",
-              destination_path.to_string_lossy().code_str(),
-              e
-            )
-          })?;
+            // Move it to the destination.
+            rename(&intermediate, &destination).map_err(|e| {
+                format!(
+                    "Unable to move file {} to destination {}. Details: {}.",
+                    intermediate.to_string_lossy().code_str(),
+                    destination.to_string_lossy().code_str(),
+                    e
+                )
+            })?;
         } else {
-          // It's a file. Move it to the destination.
-          rename(entry_path, &destination_path).map_err(|e| {
-            format!(
+            // It's a directory. Traverse it.
+            for entry in WalkDir::new(&intermediate) {
+                // If we run into an error traversing the filesystem, report it.
+                let entry = entry.map_err(|e| {
+                    format!(
+                        "Unable to traverse directory {}. Details: {}.",
+                        intermediate.to_string_lossy().code_str(),
+                        e
+                    )
+                })?;
+
+                // Figure out what needs to go where. The `unwrap` is safe because
+                // `entry` is guaranteed to be inside `intermediate` (or equal to it).
+                let entry_path = entry.path();
+                let destination_path = destination
+                    .join(entry_path.strip_prefix(&intermediate).unwrap());
+
+                // Check if the current entry is a file or a directory.
+                if entry.file_type().is_dir() {
+                    // It's a directory. Create a directory at the destination.
+                    create_dir_all(&destination_path).map_err(|e| {
+                        format!(
+                            "Unable to create directory {}. Details: {}.",
+                            destination_path.to_string_lossy().code_str(),
+                            e
+                        )
+                    })?;
+                } else {
+                    // It's a file. Move it to the destination.
+                    rename(entry_path, &destination_path).map_err(|e| {
+                        format!(
               "Unable to move file {} to destination {}. Details: {}.",
               entry_path.to_string_lossy().code_str(),
               destination_path.to_string_lossy().code_str(),
               e
             )
-          })?;
+                    })?;
+                }
+            }
         }
-      }
     }
-  }
 
-  Ok(())
+    Ok(())
 }
 
 // Start a container.
 pub fn start_container(
-  container: &str,
-  command: &str,
-  interrupted: &Arc<AtomicBool>,
+    container: &str,
+    command: &str,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-  debug!("Starting container {}\u{2026}", container.code_str());
-  run_loud_stdin(
-    "Unable to start container.",
-    &["container", "start", "--attach", "--interactive", container],
-    |stdin| {
-      write!(stdin, "{}", command).map_err(|e| {
-        format!(
-          "Unable to send command {} to the container. Details: {}.",
-          command.code_str(),
-          e
-        )
-      })?;
+    debug!("Starting container {}\u{2026}", container.code_str());
+    run_loud_stdin(
+        "Unable to start container.",
+        &["container", "start", "--attach", "--interactive", container],
+        |stdin| {
+            write!(stdin, "{}", command).map_err(|e| {
+                format!(
+                    "Unable to send command {} to the container. Details: {}.",
+                    command.code_str(),
+                    e
+                )
+            })?;
 
-      Ok(())
-    },
-    interrupted,
-  )
-  .map(|_| ())
+            Ok(())
+        },
+        interrupted,
+    )
+    .map(|_| ())
 }
 
 // Stop a container.
 pub fn stop_container(
-  container: &str,
-  interrupted: &Arc<AtomicBool>,
+    container: &str,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-  debug!("Stopping container {}\u{2026}", container.code_str());
-  run_quiet(
-    "Stopping container\u{2026}",
-    "Unable to stop container.",
-    &["container", "stop", container],
-    interrupted,
-  )
-  .map(|_| ())
+    debug!("Stopping container {}\u{2026}", container.code_str());
+    run_quiet(
+        "Stopping container\u{2026}",
+        "Unable to stop container.",
+        &["container", "stop", container],
+        interrupted,
+    )
+    .map(|_| ())
 }
 
 // Commit a container to an image.
 pub fn commit_container(
-  container: &str,
-  image: &str,
-  interrupted: &Arc<AtomicBool>,
+    container: &str,
+    image: &str,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-  debug!(
-    "Committing container {} to image {}\u{2026}",
-    container.code_str(),
-    image.code_str()
-  );
-  run_quiet(
-    "Committing container\u{2026}",
-    "Unable to commit container.",
-    &["container", "commit", container, image],
-    interrupted,
-  )
-  .map(|_| ())
+    debug!(
+        "Committing container {} to image {}\u{2026}",
+        container.code_str(),
+        image.code_str()
+    );
+    run_quiet(
+        "Committing container\u{2026}",
+        "Unable to commit container.",
+        &["container", "commit", container, image],
+        interrupted,
+    )
+    .map(|_| ())
 }
 
 // Delete a container.
 pub fn delete_container(
-  container: &str,
-  interrupted: &Arc<AtomicBool>,
+    container: &str,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-  debug!("Deleting container {}\u{2026}", container.code_str());
-  run_quiet(
-    "Deleting container\u{2026}",
-    "Unable to delete container.",
-    &["container", "rm", "--force", container],
-    interrupted,
-  )
-  .map(|_| ())
+    debug!("Deleting container {}\u{2026}", container.code_str());
+    run_quiet(
+        "Deleting container\u{2026}",
+        "Unable to delete container.",
+        &["container", "rm", "--force", container],
+        interrupted,
+    )
+    .map(|_| ())
 }
 
 // Run an interactive shell.
 pub fn spawn_shell(
-  image: &str,
-  interrupted: &Arc<AtomicBool>,
+    image: &str,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-  debug!(
-    "Spawning an interactive shell for image {}\u{2026}",
-    image.code_str()
-  );
-  run_attach(
-    "The shell exited with a failure.",
-    &[
-      "container",
-      "run",
-      "--rm",
-      "--interactive",
-      "--tty",
-      "--init", // [ref:--init]
-      image,
-      "/bin/su", // We use `su` rather than `sh` to use the root user's shell.
-    ],
-    interrupted,
-  )
+    debug!(
+        "Spawning an interactive shell for image {}\u{2026}",
+        image.code_str()
+    );
+    run_attach(
+        "The shell exited with a failure.",
+        &[
+            "container",
+            "run",
+            "--rm",
+            "--interactive",
+            "--tty",
+            "--init", // [ref:--init]
+            image,
+            "/bin/su", // We use `su` rather than `sh` to use the root user's shell.
+        ],
+        interrupted,
+    )
 }
 
 // Run a command, forward its standard error stream, and return its standard
 // output.
 fn run_quiet(
-  spinner_message: &str,
-  error: &str,
-  args: &[&str],
-  interrupted: &Arc<AtomicBool>,
+    spinner_message: &str,
+    error: &str,
+    args: &[&str],
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<String, String> {
-  let _guard = spin(spinner_message);
+    let _guard = spin(spinner_message);
 
-  let output = command(args).stdin(Stdio::null()).output().map_err(|e| {
-    format!(
-      "{} Perhaps you don't have Docker installed. Details: {}.",
-      error, e
-    )
-  })?;
+    let output = command(args).stdin(Stdio::null()).output().map_err(|e| {
+        format!(
+            "{} Perhaps you don't have Docker installed. Details: {}.",
+            error, e
+        )
+    })?;
 
-  if output.status.success() {
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
-  } else {
-    Err(if output.status.code().is_none() {
-      interrupted.store(true, Ordering::SeqCst);
-      super::INTERRUPT_MESSAGE.to_owned()
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
     } else {
-      format!(
-        "{} Details:\n{}",
-        error,
-        String::from_utf8_lossy(&output.stderr)
-      )
-    })
-  }
+        Err(if output.status.code().is_none() {
+            interrupted.store(true, Ordering::SeqCst);
+            super::INTERRUPT_MESSAGE.to_owned()
+        } else {
+            format!(
+                "{} Details:\n{}",
+                error,
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })
+    }
 }
 
 // Run a command, forward its standard error stream, and return its standard
 // output. Accepts a closure which receives a pipe to the standard input stream
 // of the child process.
 fn run_quiet_stdin<W: FnOnce(&mut ChildStdin) -> Result<(), String>>(
-  spinner_message: &str,
-  error: &str,
-  args: &[&str],
-  writer: W,
-  interrupted: &Arc<AtomicBool>,
+    spinner_message: &str,
+    error: &str,
+    args: &[&str],
+    writer: W,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<String, String> {
-  let _guard = spin(spinner_message);
+    let _guard = spin(spinner_message);
 
-  let mut child = command(args)
-    .stdin(Stdio::piped()) // [tag:run_quiet_stdin_piped]
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped())
-    .spawn()
-    .map_err(|e| {
-      format!(
-        "{} Perhaps you don't have Docker installed. Details: {}.",
-        error, e
-      )
+    let mut child = command(args)
+        .stdin(Stdio::piped()) // [tag:run_quiet_stdin_piped]
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            format!(
+                "{} Perhaps you don't have Docker installed. Details: {}.",
+                error, e
+            )
+        })?;
+    writer(child.stdin.as_mut().unwrap())?; // [ref:run_quiet_stdin_piped]
+    let output = child.wait_with_output().map_err(|e| {
+        format!(
+            "{} Perhaps you don't have Docker installed. Details: {}.",
+            error, e
+        )
     })?;
-  writer(child.stdin.as_mut().unwrap())?; // [ref:run_quiet_stdin_piped]
-  let output = child.wait_with_output().map_err(|e| {
-    format!(
-      "{} Perhaps you don't have Docker installed. Details: {}.",
-      error, e
-    )
-  })?;
 
-  if output.status.success() {
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
-  } else {
-    Err(if output.status.code().is_none() {
-      interrupted.store(true, Ordering::SeqCst);
-      super::INTERRUPT_MESSAGE.to_owned()
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
     } else {
-      format!(
-        "{} Details:\n{}",
-        error,
-        String::from_utf8_lossy(&output.stderr)
-      )
-    })
-  }
+        Err(if output.status.code().is_none() {
+            interrupted.store(true, Ordering::SeqCst);
+            super::INTERRUPT_MESSAGE.to_owned()
+        } else {
+            format!(
+                "{} Details:\n{}",
+                error,
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })
+    }
 }
 
 // Run a command and forward its standard output and error streams. Accepts a
 // closure which receives a pipe to the standard input stream of the child
 // process.
 fn run_loud_stdin<W: FnOnce(&mut ChildStdin) -> Result<(), String>>(
-  error: &str,
-  args: &[&str],
-  writer: W,
-  interrupted: &Arc<AtomicBool>,
+    error: &str,
+    args: &[&str],
+    writer: W,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-  let mut child = command(args)
-    .stdin(Stdio::piped()) // [tag:run_loud_stdin_piped]
-    .spawn()
-    .map_err(|e| {
-      format!(
-        "{} Perhaps you don't have Docker installed. Details: {}.",
-        error, e
-      )
+    let mut child = command(args)
+        .stdin(Stdio::piped()) // [tag:run_loud_stdin_piped]
+        .spawn()
+        .map_err(|e| {
+            format!(
+                "{} Perhaps you don't have Docker installed. Details: {}.",
+                error, e
+            )
+        })?;
+    writer(child.stdin.as_mut().unwrap())?; // [ref:run_loud_stdin_piped]
+    let status = child.wait().map_err(|e| {
+        format!(
+            "{} Perhaps you don't have Docker installed. Details: {}.",
+            error, e
+        )
     })?;
-  writer(child.stdin.as_mut().unwrap())?; // [ref:run_loud_stdin_piped]
-  let status = child.wait().map_err(|e| {
-    format!(
-      "{} Perhaps you don't have Docker installed. Details: {}.",
-      error, e
-    )
-  })?;
 
-  if status.success() {
-    Ok(())
-  } else {
-    Err(
-      if status.code().is_none() {
-        interrupted.store(true, Ordering::SeqCst);
-        super::INTERRUPT_MESSAGE
-      } else {
-        error
-      }
-      .to_owned(),
-    )
-  }
+    if status.success() {
+        Ok(())
+    } else {
+        Err(if status.code().is_none() {
+            interrupted.store(true, Ordering::SeqCst);
+            super::INTERRUPT_MESSAGE
+        } else {
+            error
+        }
+        .to_owned())
+    }
 }
 
 // Run a command and forward its standard input, output, and error streams.
 fn run_attach(
-  error: &str,
-  args: &[&str],
-  interrupted: &Arc<AtomicBool>,
+    error: &str,
+    args: &[&str],
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-  let status = command(args).status().map_err(|e| {
-    format!(
-      "{} Perhaps you don't have Docker installed. Details: {}.",
-      error, e
-    )
-  })?;
+    let status = command(args).status().map_err(|e| {
+        format!(
+            "{} Perhaps you don't have Docker installed. Details: {}.",
+            error, e
+        )
+    })?;
 
-  if status.success() {
-    Ok(())
-  } else {
-    Err(
-      if status.code().is_none() {
-        interrupted.store(true, Ordering::SeqCst);
-        super::INTERRUPT_MESSAGE
-      } else {
-        error
-      }
-      .to_owned(),
-    )
-  }
+    if status.success() {
+        Ok(())
+    } else {
+        Err(if status.code().is_none() {
+            interrupted.store(true, Ordering::SeqCst);
+            super::INTERRUPT_MESSAGE
+        } else {
+            error
+        }
+        .to_owned())
+    }
 }
 
 // Construct a Docker `Command` from an array of arguments.
 fn command(args: &[&str]) -> Command {
-  let mut command = Command::new("docker");
-  for arg in args {
-    command.arg(arg);
-  }
-  command
+    let mut command = Command::new("docker");
+    for arg in args {
+        command.arg(arg);
+    }
+    command
 }
 
 #[cfg(test)]
 mod tests {
-  use crate::docker::random_tag;
+    use crate::docker::random_tag;
 
-  #[test]
-  fn random_impure() {
-    assert_ne!(random_tag(), random_tag());
-  }
+    #[test]
+    fn random_impure() {
+        assert_ne!(random_tag(), random_tag());
+    }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -4,85 +4,88 @@ use colored::{ColoredString, Colorize};
 // This trait has a function for formatting "code-like" text, such as a task
 // name or a file path.
 pub trait CodeStr {
-  fn code_str(&self) -> ColoredString;
+    fn code_str(&self) -> ColoredString;
 }
 
 impl CodeStr for str {
-  fn code_str(&self) -> ColoredString {
-    if atty::is(Stream::Stdout) {
-      self.magenta()
-    } else {
-      ColoredString::from(&format!("`{}`", self) as &Self)
+    fn code_str(&self) -> ColoredString {
+        if atty::is(Stream::Stdout) {
+            self.magenta()
+        } else {
+            ColoredString::from(&format!("`{}`", self) as &Self)
+        }
     }
-  }
 }
 
 // This function takes a number and a noun and returns a string representing
 // the noun with the given multiplicity (pluralizing if necessary). For
 // example, (3, "cow") becomes "3 cows".
 pub fn number(n: usize, noun: &str) -> String {
-  if n == 1 {
-    format!("{} {}", n, noun)
-  } else {
-    format!("{} {}s", n, noun)
-  }
+    if n == 1 {
+        format!("{} {}", n, noun)
+    } else {
+        format!("{} {}s", n, noun)
+    }
 }
 
 // This function takes an array of strings and returns a comma-separated list
 // with the word "and" (and an Oxford comma, if applicable) between the last
 // two items.
 pub fn series(items: &[String]) -> String {
-  match items.len() {
-    0 => "".to_owned(),
-    1 => items[0].clone(),
-    2 => format!("{} and {}", items[0], items[1]),
-    _ => format!(
-      "{}, and {}",
-      items[..items.len() - 1].join(", "),
-      items[items.len() - 1]
-    ),
-  }
+    match items.len() {
+        0 => "".to_owned(),
+        1 => items[0].clone(),
+        2 => format!("{} and {}", items[0], items[1]),
+        _ => format!(
+            "{}, and {}",
+            items[..items.len() - 1].join(", "),
+            items[items.len() - 1]
+        ),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  use crate::format::{number, series};
+    use crate::format::{number, series};
 
-  #[test]
-  fn number_zero() {
-    assert_eq!(number(0, "cow"), "0 cows");
-  }
+    #[test]
+    fn number_zero() {
+        assert_eq!(number(0, "cow"), "0 cows");
+    }
 
-  #[test]
-  fn number_one() {
-    assert_eq!(number(1, "cow"), "1 cow");
-  }
+    #[test]
+    fn number_one() {
+        assert_eq!(number(1, "cow"), "1 cow");
+    }
 
-  #[test]
-  fn number_two() {
-    assert_eq!(number(2, "cow"), "2 cows");
-  }
+    #[test]
+    fn number_two() {
+        assert_eq!(number(2, "cow"), "2 cows");
+    }
 
-  #[test]
-  fn series_empty() {
-    assert_eq!(series(&[]), "");
-  }
+    #[test]
+    fn series_empty() {
+        assert_eq!(series(&[]), "");
+    }
 
-  #[test]
-  fn series_one() {
-    assert_eq!(series(&["foo".to_owned()]), "foo");
-  }
+    #[test]
+    fn series_one() {
+        assert_eq!(series(&["foo".to_owned()]), "foo");
+    }
 
-  #[test]
-  fn series_two() {
-    assert_eq!(series(&["foo".to_owned(), "bar".to_owned()]), "foo and bar");
-  }
+    #[test]
+    fn series_two() {
+        assert_eq!(
+            series(&["foo".to_owned(), "bar".to_owned()]),
+            "foo and bar"
+        );
+    }
 
-  #[test]
-  fn series_three() {
-    assert_eq!(
-      series(&["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]),
-      "foo, bar, and baz"
-    );
-  }
+    #[test]
+    fn series_three() {
+        assert_eq!(
+            series(&["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]),
+            "foo, bar, and baz"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,20 +14,20 @@ use clap::{App, AppSettings, Arg};
 use env_logger::{fmt::Color, Builder};
 use log::{Level, LevelFilter};
 use std::{
-  collections::{HashMap, HashSet},
-  convert::AsRef,
-  env,
-  env::current_dir,
-  fs,
-  io::{stdout, Write},
-  path::Path,
-  path::PathBuf,
-  process::exit,
-  str::FromStr,
-  sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
-  },
+    collections::{HashMap, HashSet},
+    convert::AsRef,
+    env,
+    env::current_dir,
+    fs,
+    io::{stdout, Write},
+    path::Path,
+    path::PathBuf,
+    process::exit,
+    str::FromStr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
 };
 
 #[macro_use]
@@ -63,367 +63,371 @@ const INTERRUPT_MESSAGE: &str = "Interrupted.";
 
 // Set up the logger.
 fn set_up_logging() {
-  Builder::new()
-    .filter_module(
-      module_path!(),
-      LevelFilter::from_str(
-        &env::var("LOG_LEVEL")
-          .unwrap_or_else(|_| DEFAULT_LOG_LEVEL.to_string()),
-      )
-      .unwrap_or_else(|_| DEFAULT_LOG_LEVEL),
-    )
-    .format(|buf, record| {
-      let mut style = buf.style();
-      style.set_bold(true);
-      match record.level() {
-        Level::Error => {
-          style.set_color(Color::Red);
-        }
-        Level::Warn => {
-          style.set_color(Color::Yellow);
-        }
-        Level::Info => {
-          style.set_color(Color::Green);
-        }
-        Level::Debug | Level::Trace => {
-          style.set_color(Color::Blue);
-        }
-      }
+    Builder::new()
+        .filter_module(
+            module_path!(),
+            LevelFilter::from_str(
+                &env::var("LOG_LEVEL")
+                    .unwrap_or_else(|_| DEFAULT_LOG_LEVEL.to_string()),
+            )
+            .unwrap_or_else(|_| DEFAULT_LOG_LEVEL),
+        )
+        .format(|buf, record| {
+            let mut style = buf.style();
+            style.set_bold(true);
+            match record.level() {
+                Level::Error => {
+                    style.set_color(Color::Red);
+                }
+                Level::Warn => {
+                    style.set_color(Color::Yellow);
+                }
+                Level::Info => {
+                    style.set_color(Color::Green);
+                }
+                Level::Debug | Level::Trace => {
+                    style.set_color(Color::Blue);
+                }
+            }
 
-      writeln!(
-        buf,
-        "{} {}",
-        style.value(format!("[{}]", record.level())),
-        record.args().to_string()
-      )
-    })
-    .init();
+            writeln!(
+                buf,
+                "{} {}",
+                style.value(format!("[{}]", record.level())),
+                record.args().to_string()
+            )
+        })
+        .init();
 }
 
 // Set up the signal handlers.
 fn set_up_signal_handlers(
-  interrupted: Arc<AtomicBool>,
-  active_containers: Arc<Mutex<HashSet<String>>>,
+    interrupted: Arc<AtomicBool>,
+    active_containers: Arc<Mutex<HashSet<String>>>,
 ) -> Result<(), String> {
-  // If Toast is in the foreground process group for some TTY, the process will
-  // receive a SIGINT when the user types CTRL+C at the terminal. The default
-  // behavior is to crash when this signal is received. However, we would
-  // rather clean up resources before terminating, so we trap the signal here.
-  // This code also traps SIGTERM, because we compile the `ctrlc` crate with
-  // the `termination` feature [ref:ctrlc_term].
-  ctrlc::set_handler(move || {
-    // Let the rest of the program know the user wants to quit.
-    if interrupted.swap(true, Ordering::SeqCst) {
-      // Stop any active containers. The `unwrap` will only fail if a panic
-      // already occurred.
-      for container in &*active_containers.lock().unwrap() {
-        if let Err(e) = docker::stop_container(&container, &interrupted) {
-          error!("{}", e);
-        }
-      }
+    // If Toast is in the foreground process group for some TTY, the process will
+    // receive a SIGINT when the user types CTRL+C at the terminal. The default
+    // behavior is to crash when this signal is received. However, we would
+    // rather clean up resources before terminating, so we trap the signal here.
+    // This code also traps SIGTERM, because we compile the `ctrlc` crate with
+    // the `termination` feature [ref:ctrlc_term].
+    ctrlc::set_handler(move || {
+        // Let the rest of the program know the user wants to quit.
+        if interrupted.swap(true, Ordering::SeqCst) {
+            // Stop any active containers. The `unwrap` will only fail if a panic
+            // already occurred.
+            for container in &*active_containers.lock().unwrap() {
+                if let Err(e) =
+                    docker::stop_container(&container, &interrupted)
+                {
+                    error!("{}", e);
+                }
+            }
 
-      // We may have been in the middle of printing a line of output. Here we
-      // print a newline to prepare for further printing.
-      let _ = stdout().write(b"\n");
-    }
-  })
-  .map_err(|e| format!("Error installing signal handler. Details: {}.", e))
+            // We may have been in the middle of printing a line of output. Here we
+            // print a newline to prepare for further printing.
+            let _ = stdout().write(b"\n");
+        }
+    })
+    .map_err(|e| format!("Error installing signal handler. Details: {}.", e))
 }
 
 // Convert a string (from a command-line argument) into a Boolean.
 fn parse_bool(s: &str) -> Result<bool, String> {
-  let normalized = s.trim().to_lowercase();
-  match normalized.as_ref() {
-    "true" | "yes" => Ok(true),
-    "false" | "no" => Ok(false),
-    _ => Err(format!("{} is not a Boolean.", s.code_str())),
-  }
+    let normalized = s.trim().to_lowercase();
+    match normalized.as_ref() {
+        "true" | "yes" => Ok(true),
+        "false" | "no" => Ok(false),
+        _ => Err(format!("{} is not a Boolean.", s.code_str())),
+    }
 }
 
 // This struct represents the command-line arguments.
 pub struct Settings {
-  toastfile_path: PathBuf,
-  docker_repo: String,
-  read_local_cache: bool,
-  write_local_cache: bool,
-  read_remote_cache: bool,
-  write_remote_cache: bool,
-  spawn_shell: bool,
-  tasks: Option<Vec<String>>,
+    toastfile_path: PathBuf,
+    docker_repo: String,
+    read_local_cache: bool,
+    write_local_cache: bool,
+    read_remote_cache: bool,
+    write_remote_cache: bool,
+    spawn_shell: bool,
+    tasks: Option<Vec<String>>,
 }
 
 // Parse the command-line arguments;
 fn settings() -> Result<Settings, String> {
-  let matches = App::new("Toast")
-    .version(VERSION)
-    .version_short("v")
-    .author("Stephan Boyer <stephan@stephanboyer.com>")
-    .about("Toast is a containerized build system.")
-    .setting(AppSettings::ColoredHelp)
-    .setting(AppSettings::NextLineHelp)
-    .setting(AppSettings::UnifiedHelpMessage)
-    .arg(
-      Arg::with_name(TOASTFILE_ARG)
-        .short("f")
-        .long(TOASTFILE_ARG)
-        .value_name("PATH")
-        .help("Sets the path to the toastfile")
-        .takes_value(true),
-    )
-    .arg(
-      Arg::with_name(CONFIG_FILE_ARG)
-        .short("c")
-        .long(CONFIG_FILE_ARG)
-        .value_name("PATH")
-        .help("Sets the path of the config file")
-        .takes_value(true),
-    )
-    .arg(
-      Arg::with_name(READ_LOCAL_CACHE_ARG)
-        .long(READ_LOCAL_CACHE_ARG)
-        .value_name("BOOL")
-        .help("Sets whether local cache reading is enabled")
-        .takes_value(true),
-    )
-    .arg(
-      Arg::with_name(WRITE_LOCAL_CACHE_ARG)
-        .long(WRITE_LOCAL_CACHE_ARG)
-        .value_name("BOOL")
-        .help("Sets whether local cache writing is enabled")
-        .takes_value(true),
-    )
-    .arg(
-      Arg::with_name(READ_REMOTE_CACHE_ARG)
-        .long(READ_REMOTE_CACHE_ARG)
-        .value_name("BOOL")
-        .help("Sets whether remote cache reading is enabled")
-        .takes_value(true),
-    )
-    .arg(
-      Arg::with_name(WRITE_REMOTE_CACHE_ARG)
-        .long(WRITE_REMOTE_CACHE_ARG)
-        .value_name("BOOL")
-        .help("Sets whether remote cache writing is enabled")
-        .takes_value(true),
-    )
-    .arg(
-      Arg::with_name(REPO_ARG)
-        .short("r")
-        .long(REPO_ARG)
-        .value_name("REPO")
-        .help("Sets the Docker repository")
-        .takes_value(true),
-    )
-    .arg(
-      Arg::with_name(SHELL_ARG)
-        .short("s")
-        .long(SHELL_ARG)
-        .help("Drops you into a shell after the tasks are finished"),
-    )
-    .arg(
-      Arg::with_name(TASKS_ARG)
-        .value_name("TASKS")
-        .multiple(true)
-        .help("Sets the tasks to run"),
-    )
-    .get_matches();
+    let matches = App::new("Toast")
+        .version(VERSION)
+        .version_short("v")
+        .author("Stephan Boyer <stephan@stephanboyer.com>")
+        .about("Toast is a containerized build system.")
+        .setting(AppSettings::ColoredHelp)
+        .setting(AppSettings::NextLineHelp)
+        .setting(AppSettings::UnifiedHelpMessage)
+        .arg(
+            Arg::with_name(TOASTFILE_ARG)
+                .short("f")
+                .long(TOASTFILE_ARG)
+                .value_name("PATH")
+                .help("Sets the path to the toastfile")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(CONFIG_FILE_ARG)
+                .short("c")
+                .long(CONFIG_FILE_ARG)
+                .value_name("PATH")
+                .help("Sets the path of the config file")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(READ_LOCAL_CACHE_ARG)
+                .long(READ_LOCAL_CACHE_ARG)
+                .value_name("BOOL")
+                .help("Sets whether local cache reading is enabled")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(WRITE_LOCAL_CACHE_ARG)
+                .long(WRITE_LOCAL_CACHE_ARG)
+                .value_name("BOOL")
+                .help("Sets whether local cache writing is enabled")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(READ_REMOTE_CACHE_ARG)
+                .long(READ_REMOTE_CACHE_ARG)
+                .value_name("BOOL")
+                .help("Sets whether remote cache reading is enabled")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(WRITE_REMOTE_CACHE_ARG)
+                .long(WRITE_REMOTE_CACHE_ARG)
+                .value_name("BOOL")
+                .help("Sets whether remote cache writing is enabled")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(REPO_ARG)
+                .short("r")
+                .long(REPO_ARG)
+                .value_name("REPO")
+                .help("Sets the Docker repository")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(SHELL_ARG)
+                .short("s")
+                .long(SHELL_ARG)
+                .help("Drops you into a shell after the tasks are finished"),
+        )
+        .arg(
+            Arg::with_name(TASKS_ARG)
+                .value_name("TASKS")
+                .multiple(true)
+                .help("Sets the tasks to run"),
+        )
+        .get_matches();
 
-  // Find the toastfile.
-  let toastfile_path = matches.value_of(TOASTFILE_ARG).map_or_else(
-    || {
-      let mut candidate_dir = current_dir().map_err(|e| {
-        format!("Unable to determine working directory. Details: {}.", e)
-      })?;
-      loop {
-        let candidate_path = candidate_dir.join(TOASTFILE_DEFAULT_NAME);
-        if let Ok(metadata) = fs::metadata(&candidate_path) {
-          if metadata.file_type().is_file() {
-            return Ok(candidate_path);
-          }
-        }
-        if !candidate_dir.pop() {
-          return Err(format!(
-            "Unable to locate file {}.",
-            TOASTFILE_DEFAULT_NAME.code_str()
-          ));
-        }
-      }
-    },
-    |x| Ok(Path::new(x).to_owned()),
-  )?;
+    // Find the toastfile.
+    let toastfile_path = matches.value_of(TOASTFILE_ARG).map_or_else(
+        || {
+            let mut candidate_dir = current_dir().map_err(|e| {
+                format!(
+                    "Unable to determine working directory. Details: {}.",
+                    e
+                )
+            })?;
+            loop {
+                let candidate_path =
+                    candidate_dir.join(TOASTFILE_DEFAULT_NAME);
+                if let Ok(metadata) = fs::metadata(&candidate_path) {
+                    if metadata.file_type().is_file() {
+                        return Ok(candidate_path);
+                    }
+                }
+                if !candidate_dir.pop() {
+                    return Err(format!(
+                        "Unable to locate file {}.",
+                        TOASTFILE_DEFAULT_NAME.code_str()
+                    ));
+                }
+            }
+        },
+        |x| Ok(Path::new(x).to_owned()),
+    )?;
 
-  // Read the config file path.
-  let default_config_file_path =
-    dirs::config_dir().map(|path| path.join(CONFIG_FILE_XDG_PATH));
-  let config_file_path = matches.value_of(CONFIG_FILE_ARG).map_or_else(
-    || default_config_file_path,
-    |path| Some(PathBuf::from(path)),
-  );
+    // Read the config file path.
+    let default_config_file_path =
+        dirs::config_dir().map(|path| path.join(CONFIG_FILE_XDG_PATH));
+    let config_file_path = matches.value_of(CONFIG_FILE_ARG).map_or_else(
+        || default_config_file_path,
+        |path| Some(PathBuf::from(path)),
+    );
 
-  // Parse the config file.
-  let config_data = config_file_path
-    .as_ref()
-    .and_then(|path| {
-      debug!(
-        "Attempting to load configuration file {}\u{2026}",
-        path.to_string_lossy().code_str()
-      );
-      fs::read_to_string(path).ok()
-    })
-    .map_or_else(
-      || {
-        debug!(
+    // Parse the config file.
+    let config_data = config_file_path
+        .as_ref()
+        .and_then(|path| {
+            debug!(
+                "Attempting to load configuration file {}\u{2026}",
+                path.to_string_lossy().code_str()
+            );
+            fs::read_to_string(path).ok()
+        })
+        .map_or_else(
+            || {
+                debug!(
           "Configuration file not found. Using the default configuration."
         );
-        config::EMPTY_CONFIG.to_owned()
-      },
-      |data| {
-        debug!("Found it.");
-        data
-      },
-    );
-  let config = config::parse(&config_data).map_err(|e| {
-    format!(
-      "Unable to parse file {}. Details: {}",
-      config_file_path
-        .as_ref()
-        .unwrap()
-        .to_string_lossy()
-        .code_str(), // Manually verified safe
-      e
-    )
-  })?;
+                config::EMPTY_CONFIG.to_owned()
+            },
+            |data| {
+                debug!("Found it.");
+                data
+            },
+        );
+    let config = config::parse(&config_data).map_err(|e| {
+        format!(
+            "Unable to parse file {}. Details: {}",
+            config_file_path
+                .as_ref()
+                .unwrap()
+                .to_string_lossy()
+                .code_str(), // Manually verified safe
+            e
+        )
+    })?;
 
-  // Read the local caching switches.
-  let read_local_cache = matches
-    .value_of(READ_LOCAL_CACHE_ARG)
-    .map_or(Ok(config.read_local_cache), |s| parse_bool(s))?;
-  let write_local_cache = matches
-    .value_of(WRITE_LOCAL_CACHE_ARG)
-    .map_or(Ok(config.write_local_cache), |s| parse_bool(s))?;
+    // Read the local caching switches.
+    let read_local_cache = matches
+        .value_of(READ_LOCAL_CACHE_ARG)
+        .map_or(Ok(config.read_local_cache), |s| parse_bool(s))?;
+    let write_local_cache = matches
+        .value_of(WRITE_LOCAL_CACHE_ARG)
+        .map_or(Ok(config.write_local_cache), |s| parse_bool(s))?;
 
-  // Read the remote caching switches.
-  let read_remote_cache = matches
-    .value_of(READ_REMOTE_CACHE_ARG)
-    .map_or(Ok(config.read_remote_cache), |s| parse_bool(s))?;
-  let write_remote_cache = matches
-    .value_of(WRITE_REMOTE_CACHE_ARG)
-    .map_or(Ok(config.write_remote_cache), |s| parse_bool(s))?;
+    // Read the remote caching switches.
+    let read_remote_cache = matches
+        .value_of(READ_REMOTE_CACHE_ARG)
+        .map_or(Ok(config.read_remote_cache), |s| parse_bool(s))?;
+    let write_remote_cache = matches
+        .value_of(WRITE_REMOTE_CACHE_ARG)
+        .map_or(Ok(config.write_remote_cache), |s| parse_bool(s))?;
 
-  // Read the Docker repo.
-  let docker_repo = matches
-    .value_of(REPO_ARG)
-    .unwrap_or(&config.docker_repo)
-    .to_owned();
+    // Read the Docker repo.
+    let docker_repo = matches
+        .value_of(REPO_ARG)
+        .unwrap_or(&config.docker_repo)
+        .to_owned();
 
-  // Read the shell switch.
-  let spawn_shell = matches.is_present(SHELL_ARG);
+    // Read the shell switch.
+    let spawn_shell = matches.is_present(SHELL_ARG);
 
-  // Read the list of tasks.
-  let tasks = matches.values_of(TASKS_ARG).map(|tasks| {
-    tasks
-      .map(std::borrow::ToOwned::to_owned)
-      .collect::<Vec<_>>()
-  });
+    // Read the list of tasks.
+    let tasks = matches.values_of(TASKS_ARG).map(|tasks| {
+        tasks
+            .map(std::borrow::ToOwned::to_owned)
+            .collect::<Vec<_>>()
+    });
 
-  Ok(Settings {
-    toastfile_path,
-    read_local_cache,
-    write_local_cache,
-    read_remote_cache,
-    write_remote_cache,
-    docker_repo,
-    spawn_shell,
-    tasks,
-  })
+    Ok(Settings {
+        toastfile_path,
+        read_local_cache,
+        write_local_cache,
+        read_remote_cache,
+        write_remote_cache,
+        docker_repo,
+        spawn_shell,
+        tasks,
+    })
 }
 
 // Parse a toastfile.
 fn parse_toastfile(
-  toastfile_path: &Path,
+    toastfile_path: &Path,
 ) -> Result<toastfile::Toastfile, String> {
-  // Read the file from disk.
-  let toastfile_data = fs::read_to_string(toastfile_path).map_err(|e| {
-    format!(
-      "Unable to read file {}. Details: {}.",
-      toastfile_path.to_string_lossy().code_str(),
-      e
-    )
-  })?;
+    // Read the file from disk.
+    let toastfile_data = fs::read_to_string(toastfile_path).map_err(|e| {
+        format!(
+            "Unable to read file {}. Details: {}.",
+            toastfile_path.to_string_lossy().code_str(),
+            e
+        )
+    })?;
 
-  // Parse it.
-  toastfile::parse(&toastfile_data).map_err(|e| {
-    format!(
-      "Unable to parse file {}. Details: {}",
-      toastfile_path.to_string_lossy().code_str(),
-      e
-    )
-  })
+    // Parse it.
+    toastfile::parse(&toastfile_data).map_err(|e| {
+        format!(
+            "Unable to parse file {}. Details: {}",
+            toastfile_path.to_string_lossy().code_str(),
+            e
+        )
+    })
 }
 
 // Determine which tasks the user wants to run.
 fn get_roots<'a>(
-  settings: &'a Settings,
-  toastfile: &'a toastfile::Toastfile,
+    settings: &'a Settings,
+    toastfile: &'a toastfile::Toastfile,
 ) -> Result<Vec<&'a str>, String> {
-  settings.tasks.as_ref().map_or_else(
-    || {
-      // The user didn't provide any tasks. Check if there is a default task.
-      if let Some(default) = &toastfile.default {
-        // There is a default. Use it.
-        Ok(vec![default.as_ref()])
-      } else {
-        // There is no default. Run all the tasks.
-        Ok(
-          toastfile
-            .tasks
-            .keys()
-            .map(AsRef::as_ref)
-            .collect::<Vec<_>>(),
-        )
-      }
-    },
-    |tasks| {
-      // The user provided some tasks. Check that they exist, and run them.
-      for task in tasks {
-        if !toastfile.tasks.contains_key(task) {
-          // [tag:tasks_valid]
-          return Err(format!(
-            "No task named {} in {}.",
-            task.code_str(),
-            settings.toastfile_path.to_string_lossy().code_str()
-          ));
-        }
-      }
+    settings.tasks.as_ref().map_or_else(
+        || {
+            // The user didn't provide any tasks. Check if there is a default task.
+            if let Some(default) = &toastfile.default {
+                // There is a default. Use it.
+                Ok(vec![default.as_ref()])
+            } else {
+                // There is no default. Run all the tasks.
+                Ok(toastfile
+                    .tasks
+                    .keys()
+                    .map(AsRef::as_ref)
+                    .collect::<Vec<_>>())
+            }
+        },
+        |tasks| {
+            // The user provided some tasks. Check that they exist, and run them.
+            for task in tasks {
+                if !toastfile.tasks.contains_key(task) {
+                    // [tag:tasks_valid]
+                    return Err(format!(
+                        "No task named {} in {}.",
+                        task.code_str(),
+                        settings.toastfile_path.to_string_lossy().code_str()
+                    ));
+                }
+            }
 
-      Ok(tasks.iter().map(AsRef::as_ref).collect())
-    },
-  )
+            Ok(tasks.iter().map(AsRef::as_ref).collect())
+        },
+    )
 }
 
 // Fetch all the environment variables used by the tasks in the schedule.
 fn fetch_environment(
-  schedule: &[&str],
-  tasks: &HashMap<String, toastfile::Task>,
+    schedule: &[&str],
+    tasks: &HashMap<String, toastfile::Task>,
 ) -> Result<HashMap<String, String>, String> {
-  let mut env = HashMap::new();
-  let mut violations = HashMap::new();
+    let mut env = HashMap::new();
+    let mut violations = HashMap::new();
 
-  for task in schedule {
-    match toastfile::environment(&tasks[*task]) {
-      // [ref:tasks_valid]
-      Ok(env_for_task) => {
-        env.extend(env_for_task);
-      }
-      Err(vars) => {
-        violations.insert((*task).to_owned(), vars);
-      }
+    for task in schedule {
+        match toastfile::environment(&tasks[*task]) {
+            // [ref:tasks_valid]
+            Ok(env_for_task) => {
+                env.extend(env_for_task);
+            }
+            Err(vars) => {
+                violations.insert((*task).to_owned(), vars);
+            }
+        }
     }
-  }
 
-  if !violations.is_empty() {
-    // [tag:environment_valid]
-    return Err(format!(
+    if !violations.is_empty() {
+        // [tag:environment_valid]
+        return Err(format!(
       "The following tasks use variables which are missing from the environment: {}.",
       format::series(
         violations
@@ -441,166 +445,166 @@ fn fetch_environment(
           .collect::<Vec<_>>().as_ref()
       )
     ));
-  }
+    }
 
-  Ok(env)
+    Ok(env)
 }
 
 // Run some tasks.
 #[allow(clippy::too_many_arguments)]
 fn run_tasks(
-  schedule: &[&str],
-  settings: &Settings,
-  toastfile: &toastfile::Toastfile,
-  environment: &HashMap<String, String>,
-  interrupted: &Arc<AtomicBool>,
-  active_containers: &Arc<Mutex<HashSet<String>>>,
+    schedule: &[&str],
+    settings: &Settings,
+    toastfile: &toastfile::Toastfile,
+    environment: &HashMap<String, String>,
+    interrupted: &Arc<AtomicBool>,
+    active_containers: &Arc<Mutex<HashSet<String>>>,
 ) -> Result<runner::Context, (String, runner::Context)> {
-  // This variable will be `true` as long as we're executing tasks that have
-  // `cache: true`. As soon as we encounter a task with `cache: false`, this
-  // variable will be permanently set to `false`.
-  let mut caching_enabled = true;
+    // This variable will be `true` as long as we're executing tasks that have
+    // `cache: true`. As soon as we encounter a task with `cache: false`, this
+    // variable will be permanently set to `false`.
+    let mut caching_enabled = true;
 
-  // This is the cache key for the current task. We initialize it with the base
-  // image name.
-  let mut cache_key = toastfile.image.clone();
+    // This is the cache key for the current task. We initialize it with the base
+    // image name.
+    let mut cache_key = toastfile.image.clone();
 
-  // We start with the base image.
-  let mut context = runner::Context {
-    image: toastfile.image.clone(),
-    persist: true,
-    interrupted: interrupted.clone(),
-  };
+    // We start with the base image.
+    let mut context = runner::Context {
+        image: toastfile.image.clone(),
+        persist: true,
+        interrupted: interrupted.clone(),
+    };
 
-  // Run each task in the schedule.
-  for task in schedule {
-    // Fetch the data for the current task.
-    let task_data = &toastfile.tasks[*task]; // [ref:tasks_valid]
+    // Run each task in the schedule.
+    for task in schedule {
+        // Fetch the data for the current task.
+        let task_data = &toastfile.tasks[*task]; // [ref:tasks_valid]
 
-    // If the current task is not cacheable, don't read or write to any form of
-    // cache from now on.
-    caching_enabled = caching_enabled && task_data.cache;
+        // If the current task is not cacheable, don't read or write to any form of
+        // cache from now on.
+        caching_enabled = caching_enabled && task_data.cache;
 
-    // If the user wants to stop the schedule, quit now.
-    if interrupted.load(Ordering::SeqCst) {
-      return Err((INTERRUPT_MESSAGE.to_owned(), context));
+        // If the user wants to stop the schedule, quit now.
+        if interrupted.load(Ordering::SeqCst) {
+            return Err((INTERRUPT_MESSAGE.to_owned(), context));
+        }
+
+        // Run the task.
+        info!("Running task {}\u{2026}", task.code_str());
+        let (new_cache_key, new_context) = runner::run(
+            settings,
+            &environment,
+            &interrupted,
+            &active_containers,
+            task_data,
+            &cache_key,
+            caching_enabled,
+            context,
+        )?;
+
+        // Remember the cache key and context for the next task.
+        cache_key = new_cache_key;
+        context = new_context;
     }
 
-    // Run the task.
-    info!("Running task {}\u{2026}", task.code_str());
-    let (new_cache_key, new_context) = runner::run(
-      settings,
-      &environment,
-      &interrupted,
-      &active_containers,
-      task_data,
-      &cache_key,
-      caching_enabled,
-      context,
-    )?;
-
-    // Remember the cache key and context for the next task.
-    cache_key = new_cache_key;
-    context = new_context;
-  }
-
-  // Everything succeeded.
-  Ok(context)
+    // Everything succeeded.
+    Ok(context)
 }
 
 // Program entrypoint
 fn entry() -> Result<(), String> {
-  // Determine whether to print colored output.
-  colored::control::set_override(atty::is(Stream::Stdout));
+    // Determine whether to print colored output.
+    colored::control::set_override(atty::is(Stream::Stdout));
 
-  // Set up the logger.
-  set_up_logging();
+    // Set up the logger.
+    set_up_logging();
 
-  // Set up global mutable state (yum!).
-  let interrupted = Arc::new(AtomicBool::new(false));
-  let active_containers = Arc::new(Mutex::new(HashSet::<String>::new()));
+    // Set up global mutable state (yum!).
+    let interrupted = Arc::new(AtomicBool::new(false));
+    let active_containers = Arc::new(Mutex::new(HashSet::<String>::new()));
 
-  // Set up the signal handlers.
-  set_up_signal_handlers(interrupted.clone(), active_containers.clone())?;
+    // Set up the signal handlers.
+    set_up_signal_handlers(interrupted.clone(), active_containers.clone())?;
 
-  // Parse the command-line arguments;
-  let settings = settings()?;
+    // Parse the command-line arguments;
+    let settings = settings()?;
 
-  // Parse the toastfile.
-  let toastfile = parse_toastfile(&settings.toastfile_path)?;
+    // Parse the toastfile.
+    let toastfile = parse_toastfile(&settings.toastfile_path)?;
 
-  // Determine which tasks the user wants to run.
-  let root_tasks = get_roots(&settings, &toastfile)?;
+    // Determine which tasks the user wants to run.
+    let root_tasks = get_roots(&settings, &toastfile)?;
 
-  // Compute a schedule of tasks to run.
-  let schedule = schedule::compute(&toastfile, &root_tasks);
-  if !schedule.is_empty() {
-    info!(
-      "Ready to run {}: {}.",
-      format::number(schedule.len(), "task"),
-      format::series(
-        schedule
-          .iter()
-          .map(|task| format!("{}", task.code_str()))
-          .collect::<Vec<_>>()
-          .as_ref()
-      )
-    );
-  }
-
-  // Fetch all the environment variables used by the tasks in the schedule.
-  let environment = fetch_environment(&schedule, &toastfile.tasks)?;
-
-  // Execute the schedule.
-  let (succeeded, context) = match run_tasks(
-    &schedule,
-    &settings,
-    &toastfile,
-    &environment,
-    &interrupted,
-    &active_containers,
-  ) {
-    Ok(context) => {
-      // Log the success and proceed in case the user wants to be dropped into
-      // a shell.
-      info!("Done.");
-      (true, context)
+    // Compute a schedule of tasks to run.
+    let schedule = schedule::compute(&toastfile, &root_tasks);
+    if !schedule.is_empty() {
+        info!(
+            "Ready to run {}: {}.",
+            format::number(schedule.len(), "task"),
+            format::series(
+                schedule
+                    .iter()
+                    .map(|task| format!("{}", task.code_str()))
+                    .collect::<Vec<_>>()
+                    .as_ref()
+            )
+        );
     }
-    Err((e, context)) => {
-      // If the schedule failed because the user interrupted a task, quit now.
-      if interrupted.load(Ordering::SeqCst) {
-        return Err(INTERRUPT_MESSAGE.to_owned());
-      }
 
-      // Log the error and proceed in case the user wants to be dropped into a
-      // shell.
-      error!("{}", e);
-      (false, context)
+    // Fetch all the environment variables used by the tasks in the schedule.
+    let environment = fetch_environment(&schedule, &toastfile.tasks)?;
+
+    // Execute the schedule.
+    let (succeeded, context) = match run_tasks(
+        &schedule,
+        &settings,
+        &toastfile,
+        &environment,
+        &interrupted,
+        &active_containers,
+    ) {
+        Ok(context) => {
+            // Log the success and proceed in case the user wants to be dropped into
+            // a shell.
+            info!("Done.");
+            (true, context)
+        }
+        Err((e, context)) => {
+            // If the schedule failed because the user interrupted a task, quit now.
+            if interrupted.load(Ordering::SeqCst) {
+                return Err(INTERRUPT_MESSAGE.to_owned());
+            }
+
+            // Log the error and proceed in case the user wants to be dropped into a
+            // shell.
+            error!("{}", e);
+            (false, context)
+        }
+    };
+
+    // Drop the user into a shell if requested.
+    if settings.spawn_shell {
+        // Inform the user of what's about to happen.
+        info!("Preparing a shell\u{2026}");
+
+        // Spawn the shell.
+        docker::spawn_shell(&context.image, &interrupted)?;
     }
-  };
 
-  // Drop the user into a shell if requested.
-  if settings.spawn_shell {
-    // Inform the user of what's about to happen.
-    info!("Preparing a shell\u{2026}");
-
-    // Spawn the shell.
-    docker::spawn_shell(&context.image, &interrupted)?;
-  }
-
-  // Throw an error if any of the tasks failed.
-  if succeeded {
-    Ok(())
-  } else {
-    Err("One of the tasks failed.".to_owned())
-  }
+    // Throw an error if any of the tasks failed.
+    if succeeded {
+        Ok(())
+    } else {
+        Err("One of the tasks failed.".to_owned())
+    }
 }
 
 // Let the fun begin!
 fn main() {
-  // Jump to the entrypoint and handle any resulting errors.
-  if let Err(e) = entry() {
-    error!("{}", e);
-    exit(1);
-  }
+    // Jump to the entrypoint and handle any resulting errors.
+    if let Err(e) = entry() {
+        error!("{}", e);
+        exit(1);
+    }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,429 +1,445 @@
 use crate::{cache, docker, tar, toastfile::Task};
 use notify::{watcher, RecursiveMode, Watcher};
 use std::{
-  collections::{HashMap, HashSet},
-  io::{Seek, SeekFrom},
-  path::PathBuf,
-  sync::{
-    atomic::{AtomicBool, Ordering},
-    mpsc::channel,
-    Arc, Mutex,
-  },
-  thread,
-  time::Duration,
+    collections::{HashMap, HashSet},
+    io::{Seek, SeekFrom},
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::channel,
+        Arc, Mutex,
+    },
+    thread,
+    time::Duration,
 };
 use tempfile::tempfile;
 
 // A context is an image that may need to be cleaned up.
 #[derive(Clone)]
 pub struct Context {
-  pub image: String,
-  pub persist: bool,
-  pub interrupted: Arc<AtomicBool>,
+    pub image: String,
+    pub persist: bool,
+    pub interrupted: Arc<AtomicBool>,
 }
 
 impl Drop for Context {
-  fn drop(&mut self) {
-    // Delete the image if needed.
-    if !self.persist {
-      if let Err(e) = docker::delete_image(&self.image, &self.interrupted) {
-        error!("{}", e);
-      }
+    fn drop(&mut self) {
+        // Delete the image if needed.
+        if !self.persist {
+            if let Err(e) =
+                docker::delete_image(&self.image, &self.interrupted)
+            {
+                error!("{}", e);
+            }
+        }
     }
-  }
 }
 
 // Run a task and return the new cache key and context.
 #[allow(clippy::too_many_arguments)]
 pub fn run(
-  settings: &super::Settings,
-  environment: &HashMap<String, String>,
-  interrupted: &Arc<AtomicBool>,
-  active_containers: &Arc<Mutex<HashSet<String>>>,
-  task: &Task,
-  previous_cache_key: &str,
-  caching_enabled: bool,
-  context: Context,
+    settings: &super::Settings,
+    environment: &HashMap<String, String>,
+    interrupted: &Arc<AtomicBool>,
+    active_containers: &Arc<Mutex<HashSet<String>>>,
+    task: &Task,
+    previous_cache_key: &str,
+    caching_enabled: bool,
+    context: Context,
 ) -> Result<(String, Context), (String, Context)> {
-  // All relative paths are relative to where the toastfile lives.
-  let mut toastfile_dir = PathBuf::from(&settings.toastfile_path);
-  toastfile_dir.pop();
+    // All relative paths are relative to where the toastfile lives.
+    let mut toastfile_dir = PathBuf::from(&settings.toastfile_path);
+    toastfile_dir.pop();
 
-  // Create a temporary archive for the input file contents.
-  let tar_file = match tempfile() {
-    Ok(tar_file) => tar_file,
-    Err(e) => {
-      return Err((
-        format!("Unable to create temporary file. Details: {}.", e),
-        context,
-      ))
-    }
-  };
-
-  // Write to the archive.
-  let (mut tar_file, input_files_hash) = match tar::create(
-    "Reading files\u{2026}",
-    tar_file,
-    &task.input_paths,
-    &toastfile_dir,
-    &task.location,
-    &interrupted,
-  ) {
-    Ok((tar_file, input_files_hash)) => (tar_file, input_files_hash),
-    Err(e) => return Err((e, context)),
-  };
-
-  // Seek back to the beginning of the archive to prepare for copying it into
-  // the container.
-  if let Err(e) = tar_file.seek(SeekFrom::Start(0)) {
-    return Err((
-      format!("Unable to seek temporary file. Details: {}.", e),
-      context,
-    ));
-  };
-
-  // Compute the cache key.
-  let cache_key =
-    cache::key(previous_cache_key, &task, &input_files_hash, &environment);
-
-  // This is the image we'll look for in the caches.
-  let image = format!("{}:{}", settings.docker_repo, cache_key);
-
-  // Check the cache, if applicable.
-  let mut cached = false;
-  if caching_enabled {
-    // Check the local cache.
-    cached = settings.read_local_cache
-      && match docker::image_exists(&image, interrupted) {
-        Ok(exists) => exists,
-        Err(e) => return Err((e, context)),
-      };
-
-    // Check the remote cache.
-    if !cached && settings.read_remote_cache {
-      if let Err(e) = docker::pull_image(&image, interrupted) {
-        // If the pull failed, it could be because the user killed the child
-        // process (e.g., by hitting CTRL+C).
-        if interrupted.load(Ordering::SeqCst) {
-          return Err((e, context));
+    // Create a temporary archive for the input file contents.
+    let tar_file = match tempfile() {
+        Ok(tar_file) => tar_file,
+        Err(e) => {
+            return Err((
+                format!("Unable to create temporary file. Details: {}.", e),
+                context,
+            ))
         }
-      } else {
-        cached = true;
-      }
-    }
-  }
-
-  // If the task is cached, extract the output files if applicable.
-  if cached {
-    // The task is cached. Check if there are any output files.
-    if task.output_paths.is_empty() {
-      // There are no output files, so we're done.
-      Ok((
-        cache_key,
-        Context {
-          image,
-          persist: true,
-          interrupted: interrupted.clone(),
-        },
-      ))
-    } else {
-      // If we made it this far, we need to create a container from which we can
-      // extract the output files.
-      let container =
-        match docker::create_container(&image, &task.ports, interrupted) {
-          Ok(container) => container,
-          Err(e) => return Err((e, context)),
-        };
-
-      // Delete the container when we're done.
-      defer! {{
-        if let Err(e) = docker::delete_container(&container, interrupted) {
-          error!("{}", e);
-        }
-      }}
-
-      // Extract the output files from the container.
-      if let Err(e) = docker::copy_from_container(
-        &container,
-        &task.output_paths,
-        &task.location,
-        &toastfile_dir,
-        interrupted,
-      ) {
-        return Err((e, context));
-      }
-
-      // The cached image becomes the new context.
-      Ok((
-        cache_key,
-        Context {
-          image,
-          persist: true,
-          interrupted: interrupted.clone(),
-        },
-      ))
-    }
-  } else {
-    // The task is not cached. Construct the command to run inside the container.
-    let mut commands_to_run = vec![];
-
-    // Construct a small script to run the command.
-    if let Some(command) = &task.command {
-      // Set the working directory.
-      commands_to_run.push(format!(
-        "cd {}",
-        shell_escape(&task.location.to_string_lossy())
-      ));
-
-      // Set the environment variables.
-      for variable in task.environment.keys() {
-        commands_to_run.push(format!(
-          "export {}={}",
-          shell_escape(variable),
-          shell_escape(&environment[variable]), // [ref:environment_valid]
-        ));
-      }
-
-      // Run the command as the appropriate user. For readability, we prefer to
-      // use the long forms of command-line options. However, we have to use
-      // `-c COMMAND` rather than `--command=COMMAND` because BusyBox's `su`
-      // utility doesn't support the latter form, and we want to support
-      // BusyBox.
-      commands_to_run.push(format!(
-        "su -c {} {}",
-        shell_escape(&command),
-        shell_escape(&task.user)
-      ));
-    }
-
-    // Pull the image if necessary. Note that this is not considered reading
-    // from the remote cache.
-    if !match docker::image_exists(&context.image, interrupted) {
-      Ok(exists) => exists,
-      Err(e) => return Err((e, context)),
-    } {
-      if let Err(e) = docker::pull_image(&context.image, interrupted) {
-        return Err((e, context));
-      }
-    }
-
-    // Create a container from the image.
-    let container =
-      match docker::create_container(&context.image, &task.ports, interrupted)
-      {
-        Ok(container) => container,
-        Err(e) => return Err((e, context)),
-      };
-
-    // If the user interrupts the program, kill the container. The `unwrap`
-    // will only fail if a panic already occurred.
-    {
-      active_containers
-        .lock()
-        .unwrap()
-        .insert(container.to_owned());
-    }
-
-    // Delete the container when we're done.
-    defer! {{
-      // If the user interrupts the program, don't bother killing the
-      // container. We're about to kill it here. The `unwrap` will only fail if
-      // a panic already occurred.
-      {
-        active_containers.lock().unwrap().remove(&container);
-      }
-
-      // Delete the container.
-      if let Err(e) = docker::delete_container(&container, interrupted) {
-        error!("{}", e);
-      }
-    }}
-
-    // Copy files into the container. If `task.input_paths` is empty, then this
-    // will just create a directory for `task.location`.
-    if let Err(e) =
-      docker::copy_into_container(&container, &mut tar_file, interrupted)
-    {
-      return Err((e, context));
-    }
-
-    // Create a channel for publishing and listening for filesystem events.
-    let (notify_sender, notify_receiver) = channel();
-
-    // Set up a filesystem watcher.
-    let mut watcher = match watcher(notify_sender, Duration::from_millis(200))
-      .map_err(|e| {
-        format!("Unable to initialize filesystem watcher. Details: {}.", e)
-      }) {
-      Ok(watcher) => watcher,
-      Err(e) => {
-        return Err((e, context));
-      }
     };
 
-    // If applicable, subscribe to filesystem events.
-    if task.watch {
-      // We'll create a thread to process the events. First, we need to clone
-      // these values so they can be owned by the thread.
-      let toastfile_dir_clone = toastfile_dir.clone();
-      let container_clone = container.clone();
-      let interrupted_clone = interrupted.clone();
-      let task_clone = task.clone();
+    // Write to the archive.
+    let (mut tar_file, input_files_hash) = match tar::create(
+        "Reading files\u{2026}",
+        tar_file,
+        &task.input_paths,
+        &toastfile_dir,
+        &task.location,
+        &interrupted,
+    ) {
+        Ok((tar_file, input_files_hash)) => (tar_file, input_files_hash),
+        Err(e) => return Err((e, context)),
+    };
 
-      // Spawn the thread.
-      thread::spawn(move || {
-        // Wait for events.
-        while let Ok(_) = notify_receiver.recv() {
-          // Create a temporary archive for the input file contents.
-          let tar_file = match tempfile() {
-            Ok(tar_file) => tar_file,
-            Err(e) => {
-              error!("Unable to create temporary file. Details: {}.", e);
-              break;
+    // Seek back to the beginning of the archive to prepare for copying it into
+    // the container.
+    if let Err(e) = tar_file.seek(SeekFrom::Start(0)) {
+        return Err((
+            format!("Unable to seek temporary file. Details: {}.", e),
+            context,
+        ));
+    };
+
+    // Compute the cache key.
+    let cache_key =
+        cache::key(previous_cache_key, &task, &input_files_hash, &environment);
+
+    // This is the image we'll look for in the caches.
+    let image = format!("{}:{}", settings.docker_repo, cache_key);
+
+    // Check the cache, if applicable.
+    let mut cached = false;
+    if caching_enabled {
+        // Check the local cache.
+        cached = settings.read_local_cache
+            && match docker::image_exists(&image, interrupted) {
+                Ok(exists) => exists,
+                Err(e) => return Err((e, context)),
+            };
+
+        // Check the remote cache.
+        if !cached && settings.read_remote_cache {
+            if let Err(e) = docker::pull_image(&image, interrupted) {
+                // If the pull failed, it could be because the user killed the child
+                // process (e.g., by hitting CTRL+C).
+                if interrupted.load(Ordering::SeqCst) {
+                    return Err((e, context));
+                }
+            } else {
+                cached = true;
             }
-          };
+        }
+    }
 
-          // Write to the archive.
-          let (mut tar_file, _) = match tar::create(
-            "Reading files\u{2026}",
-            tar_file,
-            &task_clone.input_paths,
-            &toastfile_dir_clone,
-            &task_clone.location,
-            &interrupted_clone,
-          ) {
-            Ok((tar_file, input_files_hash)) => (tar_file, input_files_hash),
-            Err(e) => {
-              error!("{}", e);
-              break;
+    // If the task is cached, extract the output files if applicable.
+    if cached {
+        // The task is cached. Check if there are any output files.
+        if task.output_paths.is_empty() {
+            // There are no output files, so we're done.
+            Ok((
+                cache_key,
+                Context {
+                    image,
+                    persist: true,
+                    interrupted: interrupted.clone(),
+                },
+            ))
+        } else {
+            // If we made it this far, we need to create a container from which we can
+            // extract the output files.
+            let container = match docker::create_container(
+                &image,
+                &task.ports,
+                interrupted,
+            ) {
+                Ok(container) => container,
+                Err(e) => return Err((e, context)),
+            };
+
+            // Delete the container when we're done.
+            defer! {{
+              if let Err(e) = docker::delete_container(&container, interrupted) {
+                error!("{}", e);
+              }
+            }}
+
+            // Extract the output files from the container.
+            if let Err(e) = docker::copy_from_container(
+                &container,
+                &task.output_paths,
+                &task.location,
+                &toastfile_dir,
+                interrupted,
+            ) {
+                return Err((e, context));
             }
-          };
 
-          // Seek back to the beginning of the archive to prepare for copying
-          // it into the container.
-          if let Err(e) = tar_file.seek(SeekFrom::Start(0)) {
-            error!("Unable to seek temporary file. Details: {}.", e);
-            break;
-          };
+            // The cached image becomes the new context.
+            Ok((
+                cache_key,
+                Context {
+                    image,
+                    persist: true,
+                    interrupted: interrupted.clone(),
+                },
+            ))
+        }
+    } else {
+        // The task is not cached. Construct the command to run inside the container.
+        let mut commands_to_run = vec![];
 
-          // Copy files into the container. If `task.input_paths` is empty,
-          // then this will just create a directory for `task.location`.
-          if let Err(e) = docker::copy_into_container(
-            &container_clone,
-            &mut tar_file,
-            &interrupted_clone,
-          ) {
-            error!("{}", e);
-            break;
+        // Construct a small script to run the command.
+        if let Some(command) = &task.command {
+            // Set the working directory.
+            commands_to_run.push(format!(
+                "cd {}",
+                shell_escape(&task.location.to_string_lossy())
+            ));
+
+            // Set the environment variables.
+            for variable in task.environment.keys() {
+                commands_to_run.push(format!(
+                    "export {}={}",
+                    shell_escape(variable),
+                    shell_escape(&environment[variable]), // [ref:environment_valid]
+                ));
+            }
+
+            // Run the command as the appropriate user. For readability, we prefer to
+            // use the long forms of command-line options. However, we have to use
+            // `-c COMMAND` rather than `--command=COMMAND` because BusyBox's `su`
+            // utility doesn't support the latter form, and we want to support
+            // BusyBox.
+            commands_to_run.push(format!(
+                "su -c {} {}",
+                shell_escape(&command),
+                shell_escape(&task.user)
+            ));
+        }
+
+        // Pull the image if necessary. Note that this is not considered reading
+        // from the remote cache.
+        if !match docker::image_exists(&context.image, interrupted) {
+            Ok(exists) => exists,
+            Err(e) => return Err((e, context)),
+        } {
+            if let Err(e) = docker::pull_image(&context.image, interrupted) {
+                return Err((e, context));
+            }
+        }
+
+        // Create a container from the image.
+        let container = match docker::create_container(
+            &context.image,
+            &task.ports,
+            interrupted,
+        ) {
+            Ok(container) => container,
+            Err(e) => return Err((e, context)),
+        };
+
+        // If the user interrupts the program, kill the container. The `unwrap`
+        // will only fail if a panic already occurred.
+        {
+            active_containers
+                .lock()
+                .unwrap()
+                .insert(container.to_owned());
+        }
+
+        // Delete the container when we're done.
+        defer! {{
+          // If the user interrupts the program, don't bother killing the
+          // container. We're about to kill it here. The `unwrap` will only fail if
+          // a panic already occurred.
+          {
+            active_containers.lock().unwrap().remove(&container);
           }
 
-          // Inform the user that filesystem watching is working.
-          info!("Files synced.");
-        }
-      });
+          // Delete the container.
+          if let Err(e) = docker::delete_container(&container, interrupted) {
+            error!("{}", e);
+          }
+        }}
 
-      // Add the `input_paths` from this task to the filesystem watcher.
-      for path in &task.input_paths {
-        if let Err(e) = watcher.watch(path, RecursiveMode::Recursive) {
-          return Err((
-            format!(
+        // Copy files into the container. If `task.input_paths` is empty, then this
+        // will just create a directory for `task.location`.
+        if let Err(e) =
+            docker::copy_into_container(&container, &mut tar_file, interrupted)
+        {
+            return Err((e, context));
+        }
+
+        // Create a channel for publishing and listening for filesystem events.
+        let (notify_sender, notify_receiver) = channel();
+
+        // Set up a filesystem watcher.
+        let mut watcher = match watcher(
+            notify_sender,
+            Duration::from_millis(200),
+        )
+        .map_err(|e| {
+            format!("Unable to initialize filesystem watcher. Details: {}.", e)
+        }) {
+            Ok(watcher) => watcher,
+            Err(e) => {
+                return Err((e, context));
+            }
+        };
+
+        // If applicable, subscribe to filesystem events.
+        if task.watch {
+            // We'll create a thread to process the events. First, we need to clone
+            // these values so they can be owned by the thread.
+            let toastfile_dir_clone = toastfile_dir.clone();
+            let container_clone = container.clone();
+            let interrupted_clone = interrupted.clone();
+            let task_clone = task.clone();
+
+            // Spawn the thread.
+            thread::spawn(move || {
+                // Wait for events.
+                while let Ok(_) = notify_receiver.recv() {
+                    // Create a temporary archive for the input file contents.
+                    let tar_file = match tempfile() {
+                        Ok(tar_file) => tar_file,
+                        Err(e) => {
+                            error!("Unable to create temporary file. Details: {}.", e);
+                            break;
+                        }
+                    };
+
+                    // Write to the archive.
+                    let (mut tar_file, _) = match tar::create(
+                        "Reading files\u{2026}",
+                        tar_file,
+                        &task_clone.input_paths,
+                        &toastfile_dir_clone,
+                        &task_clone.location,
+                        &interrupted_clone,
+                    ) {
+                        Ok((tar_file, input_files_hash)) => {
+                            (tar_file, input_files_hash)
+                        }
+                        Err(e) => {
+                            error!("{}", e);
+                            break;
+                        }
+                    };
+
+                    // Seek back to the beginning of the archive to prepare for copying
+                    // it into the container.
+                    if let Err(e) = tar_file.seek(SeekFrom::Start(0)) {
+                        error!(
+                            "Unable to seek temporary file. Details: {}.",
+                            e
+                        );
+                        break;
+                    };
+
+                    // Copy files into the container. If `task.input_paths` is empty,
+                    // then this will just create a directory for `task.location`.
+                    if let Err(e) = docker::copy_into_container(
+                        &container_clone,
+                        &mut tar_file,
+                        &interrupted_clone,
+                    ) {
+                        error!("{}", e);
+                        break;
+                    }
+
+                    // Inform the user that filesystem watching is working.
+                    info!("Files synced.");
+                }
+            });
+
+            // Add the `input_paths` from this task to the filesystem watcher.
+            for path in &task.input_paths {
+                if let Err(e) = watcher.watch(path, RecursiveMode::Recursive) {
+                    return Err((
+                        format!(
               "Unable to register a filesystem watch path. Details: {}.",
               e
             ),
-            context,
-          ));
+                        context,
+                    ));
+                }
+            }
         }
-      }
-    }
 
-    // Start the container to run the command.
-    if docker::start_container(
-      &container,
-      &commands_to_run.join(" && "),
-      interrupted,
-    )
-    .is_err()
-    {
-      return Err((
-        if interrupted.load(Ordering::SeqCst) {
-          super::INTERRUPT_MESSAGE
+        // Start the container to run the command.
+        if docker::start_container(
+            &container,
+            &commands_to_run.join(" && "),
+            interrupted,
+        )
+        .is_err()
+        {
+            return Err((
+                if interrupted.load(Ordering::SeqCst) {
+                    super::INTERRUPT_MESSAGE
+                } else {
+                    "Command failed."
+                }
+                .to_owned(),
+                context,
+            ));
+        }
+
+        // Copy files from the container, if applicable.
+        if !task.output_paths.is_empty() {
+            if let Err(e) = docker::copy_from_container(
+                &container,
+                &task.output_paths,
+                &task.location,
+                &toastfile_dir,
+                interrupted,
+            ) {
+                return Err((e, context));
+            }
+        }
+
+        // Commit the container.
+        let (new_image, persist) = if caching_enabled
+            && settings.write_local_cache
+        {
+            (image, true)
         } else {
-          "Command failed."
+            (
+                format!("{}:{}", settings.docker_repo, docker::random_tag()),
+                false,
+            )
+        };
+        if let Err(e) =
+            docker::commit_container(&container, &new_image, interrupted)
+        {
+            return Err((e, context));
         }
-        .to_owned(),
-        context,
-      ));
-    }
 
-    // Copy files from the container, if applicable.
-    if !task.output_paths.is_empty() {
-      if let Err(e) = docker::copy_from_container(
-        &container,
-        &task.output_paths,
-        &task.location,
-        &toastfile_dir,
-        interrupted,
-      ) {
-        return Err((e, context));
-      }
-    }
+        // Write to remote cache, if applicable.
+        if caching_enabled && settings.write_remote_cache {
+            if let Err(e) = docker::push_image(&new_image, interrupted) {
+                return Err((e, context));
+            }
+        }
 
-    // Commit the container.
-    let (new_image, persist) = if caching_enabled && settings.write_local_cache
-    {
-      (image, true)
-    } else {
-      (
-        format!("{}:{}", settings.docker_repo, docker::random_tag()),
-        false,
-      )
-    };
-    if let Err(e) =
-      docker::commit_container(&container, &new_image, interrupted)
-    {
-      return Err((e, context));
+        // Return the new context.
+        Ok((
+            cache_key,
+            Context {
+                image: new_image,
+                persist,
+                interrupted: interrupted.clone(),
+            },
+        ))
     }
-
-    // Write to remote cache, if applicable.
-    if caching_enabled && settings.write_remote_cache {
-      if let Err(e) = docker::push_image(&new_image, interrupted) {
-        return Err((e, context));
-      }
-    }
-
-    // Return the new context.
-    Ok((
-      cache_key,
-      Context {
-        image: new_image,
-        persist,
-        interrupted: interrupted.clone(),
-      },
-    ))
-  }
 }
 
 // Escape a string for shell interpolation.
 fn shell_escape(command: &str) -> String {
-  format!("'{}'", command.replace("'", "'\\''"))
+    format!("'{}'", command.replace("'", "'\\''"))
 }
 
 #[cfg(test)]
 mod tests {
-  use crate::runner::shell_escape;
+    use crate::runner::shell_escape;
 
-  #[test]
-  fn shell_escape_empty() {
-    assert_eq!(shell_escape(""), "''");
-  }
+    #[test]
+    fn shell_escape_empty() {
+        assert_eq!(shell_escape(""), "''");
+    }
 
-  #[test]
-  fn shell_escape_word() {
-    assert_eq!(shell_escape("foo"), "'foo'");
-  }
+    #[test]
+    fn shell_escape_word() {
+        assert_eq!(shell_escape("foo"), "'foo'");
+    }
 
-  #[test]
-  fn shell_escape_single_quote() {
-    assert_eq!(shell_escape("f'o'o"), "'f'\\''o'\\''o'");
-  }
+    #[test]
+    fn shell_escape_single_quote() {
+        assert_eq!(shell_escape("f'o'o"), "'f'\\''o'\\''o'");
+    }
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -5,336 +5,336 @@ use std::{collections::HashSet, convert::AsRef};
 // tasks. The resulting schedule does not depend on the order of the inputs or
 // dependencies. We assume the tasks form a DAG [ref:tasks_dag].
 pub fn compute<'a>(
-  toastfile: &'a Toastfile,
-  tasks: &[&'a str],
+    toastfile: &'a Toastfile,
+    tasks: &[&'a str],
 ) -> Vec<&'a str> {
-  // Sort the input tasks to ensure the given order doesn't matter.
-  let mut roots: Vec<&'a str> = tasks.to_vec();
-  roots.sort();
+    // Sort the input tasks to ensure the given order doesn't matter.
+    let mut roots: Vec<&'a str> = tasks.to_vec();
+    roots.sort();
 
-  // We will use this set to keep track of what tasks have already been
-  // seen.
-  let mut visited: HashSet<&'a str> = HashSet::new();
+    // We will use this set to keep track of what tasks have already been
+    // seen.
+    let mut visited: HashSet<&'a str> = HashSet::new();
 
-  // This vector accumulates the final schedule.
-  let mut schedule: Vec<&'a str> = vec![];
+    // This vector accumulates the final schedule.
+    let mut schedule: Vec<&'a str> = vec![];
 
-  // For each root, compute its transitive reflexive closure, topsort it, and
-  // add it to the schedule.
-  for root in roots {
-    // The frontier is a stack, which means we are doing a depth-first
-    // traversal.
-    let mut frontier: Vec<(&'a str, bool)> = vec![(root, true)];
+    // For each root, compute its transitive reflexive closure, topsort it, and
+    // add it to the schedule.
+    for root in roots {
+        // The frontier is a stack, which means we are doing a depth-first
+        // traversal.
+        let mut frontier: Vec<(&'a str, bool)> = vec![(root, true)];
 
-    // This vector will accumulate the topsorted tasks.
-    let mut topological_sort: Vec<&'a str> = vec![];
+        // This vector will accumulate the topsorted tasks.
+        let mut topological_sort: Vec<&'a str> = vec![];
 
-    // Keep processing nodes on the frontier until there aren't any more left.
-    // [tag:schedule_frontier_nonempty]
-    while !frontier.is_empty() {
-      // Pop a task from the frontier. [ref:schedule_frontier_nonempty]
-      let (task, new) = frontier.pop().unwrap();
+        // Keep processing nodes on the frontier until there aren't any more left.
+        // [tag:schedule_frontier_nonempty]
+        while !frontier.is_empty() {
+            // Pop a task from the frontier. [ref:schedule_frontier_nonempty]
+            let (task, new) = frontier.pop().unwrap();
 
-      // Check if this is a new task or one that we are coming back to because
-      // we finished processing its dependencies.
-      if new {
-        // If we have already scheduled this root task, skip to the next one.
-        if visited.contains(task) {
-          continue;
+            // Check if this is a new task or one that we are coming back to because
+            // we finished processing its dependencies.
+            if new {
+                // If we have already scheduled this root task, skip to the next one.
+                if visited.contains(task) {
+                    continue;
+                }
+
+                // Mark this task as seen so we don't process it again.
+                visited.insert(task);
+
+                // Come back to this task once all its dependencies have been processed.
+                frontier.push((task, false));
+
+                // Add the task's dependencies to the frontier. We sort the
+                // dependencies first to ensure their original order doesn't matter.
+                // After sorting, we reverse the order of the dependencies before
+                // adding them to the frontier so that they will be processed in
+                // lexicographical order (since the frontier is a stack rather than a
+                // queue). The indexing is safe due to [ref:tasks_valid].
+                let mut dependencies: Vec<&'a str> = toastfile.tasks[task]
+                    .dependencies
+                    .iter()
+                    .map(AsRef::as_ref)
+                    .collect();
+                dependencies.sort();
+                dependencies.reverse();
+                frontier.extend(
+                    dependencies
+                        .into_iter()
+                        .map(|dependency| (dependency, true)),
+                );
+            } else {
+                // Now that the task's dependencies have been processed, schedule it.
+                topological_sort.push(task);
+            }
         }
 
-        // Mark this task as seen so we don't process it again.
-        visited.insert(task);
-
-        // Come back to this task once all its dependencies have been processed.
-        frontier.push((task, false));
-
-        // Add the task's dependencies to the frontier. We sort the
-        // dependencies first to ensure their original order doesn't matter.
-        // After sorting, we reverse the order of the dependencies before
-        // adding them to the frontier so that they will be processed in
-        // lexicographical order (since the frontier is a stack rather than a
-        // queue). The indexing is safe due to [ref:tasks_valid].
-        let mut dependencies: Vec<&'a str> = toastfile.tasks[task]
-          .dependencies
-          .iter()
-          .map(AsRef::as_ref)
-          .collect();
-        dependencies.sort();
-        dependencies.reverse();
-        frontier.extend(
-          dependencies
-            .into_iter()
-            .map(|dependency| (dependency, true)),
-        );
-      } else {
-        // Now that the task's dependencies have been processed, schedule it.
-        topological_sort.push(task);
-      }
+        // Add the topsorted tasks to the schedule.
+        schedule.extend(topological_sort);
     }
 
-    // Add the topsorted tasks to the schedule.
-    schedule.extend(topological_sort);
-  }
-
-  // Return the final schedule.
-  schedule
+    // Return the final schedule.
+    schedule
 }
 
 #[cfg(test)]
 mod tests {
-  use crate::schedule::compute;
-  use crate::toastfile::{Task, Toastfile, DEFAULT_LOCATION, DEFAULT_USER};
-  use std::{collections::HashMap, path::Path};
+    use crate::schedule::compute;
+    use crate::toastfile::{Task, Toastfile, DEFAULT_LOCATION, DEFAULT_USER};
+    use std::{collections::HashMap, path::Path};
 
-  fn task_with_dependencies(dependencies: Vec<String>) -> Task {
-    Task {
-      dependencies,
-      cache: true,
-      environment: HashMap::new(),
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: None,
+    fn task_with_dependencies(dependencies: Vec<String>) -> Task {
+        Task {
+            dependencies,
+            cache: true,
+            environment: HashMap::new(),
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: None,
+        }
     }
-  }
 
-  fn empty_task() -> Task {
-    task_with_dependencies(vec![])
-  }
+    fn empty_task() -> Task {
+        task_with_dependencies(vec![])
+    }
 
-  #[test]
-  fn schedule_empty() {
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks: HashMap::new(),
-    };
+    #[test]
+    fn schedule_empty() {
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks: HashMap::new(),
+        };
 
-    let actual: Vec<&str> = compute(&toastfile, &[]);
-    let expected: Vec<&str> = vec![];
+        let actual: Vec<&str> = compute(&toastfile, &[]);
+        let expected: Vec<&str> = vec![];
 
-    assert_eq!(actual, expected);
-  }
+        assert_eq!(actual, expected);
+    }
 
-  #[test]
-  fn schedule_single() {
-    let mut tasks = HashMap::new();
-    tasks.insert("foo".to_owned(), empty_task());
+    #[test]
+    fn schedule_single() {
+        let mut tasks = HashMap::new();
+        tasks.insert("foo".to_owned(), empty_task());
 
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
 
-    let actual: Vec<&str> = compute(&toastfile, &["foo"]);
-    let expected: Vec<&str> = vec!["foo"];
+        let actual: Vec<&str> = compute(&toastfile, &["foo"]);
+        let expected: Vec<&str> = vec!["foo"];
 
-    assert_eq!(actual, expected);
-  }
+        assert_eq!(actual, expected);
+    }
 
-  #[test]
-  fn schedule_linear() {
-    let mut tasks = HashMap::new();
-    tasks.insert("foo".to_owned(), empty_task());
-    tasks.insert(
-      "bar".to_owned(),
-      task_with_dependencies(vec!["foo".to_owned()]),
-    );
-    tasks.insert(
-      "baz".to_owned(),
-      task_with_dependencies(vec!["bar".to_owned()]),
-    );
+    #[test]
+    fn schedule_linear() {
+        let mut tasks = HashMap::new();
+        tasks.insert("foo".to_owned(), empty_task());
+        tasks.insert(
+            "bar".to_owned(),
+            task_with_dependencies(vec!["foo".to_owned()]),
+        );
+        tasks.insert(
+            "baz".to_owned(),
+            task_with_dependencies(vec!["bar".to_owned()]),
+        );
 
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
 
-    let actual: Vec<&str> = compute(&toastfile, &["baz"]);
-    let expected: Vec<&str> = vec!["foo", "bar", "baz"];
+        let actual: Vec<&str> = compute(&toastfile, &["baz"]);
+        let expected: Vec<&str> = vec!["foo", "bar", "baz"];
 
-    assert_eq!(actual, expected);
-  }
+        assert_eq!(actual, expected);
+    }
 
-  #[test]
-  fn schedule_diamond() {
-    let mut tasks = HashMap::new();
-    tasks.insert("foo".to_owned(), empty_task());
-    tasks.insert(
-      "bar".to_owned(),
-      task_with_dependencies(vec!["foo".to_owned()]),
-    );
-    tasks.insert(
-      "baz".to_owned(),
-      task_with_dependencies(vec!["foo".to_owned()]),
-    );
-    tasks.insert(
-      "qux".to_owned(),
-      task_with_dependencies(vec!["bar".to_owned(), "baz".to_owned()]),
-    );
+    #[test]
+    fn schedule_diamond() {
+        let mut tasks = HashMap::new();
+        tasks.insert("foo".to_owned(), empty_task());
+        tasks.insert(
+            "bar".to_owned(),
+            task_with_dependencies(vec!["foo".to_owned()]),
+        );
+        tasks.insert(
+            "baz".to_owned(),
+            task_with_dependencies(vec!["foo".to_owned()]),
+        );
+        tasks.insert(
+            "qux".to_owned(),
+            task_with_dependencies(vec!["bar".to_owned(), "baz".to_owned()]),
+        );
 
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
 
-    let actual: Vec<&str> = compute(&toastfile, &["qux"]);
-    let expected: Vec<&str> = vec!["foo", "bar", "baz", "qux"];
+        let actual: Vec<&str> = compute(&toastfile, &["qux"]);
+        let expected: Vec<&str> = vec!["foo", "bar", "baz", "qux"];
 
-    assert_eq!(actual, expected);
-  }
+        assert_eq!(actual, expected);
+    }
 
-  #[test]
-  fn schedule_lexicographical_tie_breaking() {
-    let mut tasks = HashMap::new();
-    tasks.insert("foo".to_owned(), empty_task());
-    tasks.insert("bar".to_owned(), empty_task());
-    tasks.insert("baz".to_owned(), empty_task());
+    #[test]
+    fn schedule_lexicographical_tie_breaking() {
+        let mut tasks = HashMap::new();
+        tasks.insert("foo".to_owned(), empty_task());
+        tasks.insert("bar".to_owned(), empty_task());
+        tasks.insert("baz".to_owned(), empty_task());
 
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
 
-    let actual: Vec<&str> = compute(&toastfile, &["foo", "bar", "baz"]);
-    let expected: Vec<&str> = vec!["bar", "baz", "foo"];
+        let actual: Vec<&str> = compute(&toastfile, &["foo", "bar", "baz"]);
+        let expected: Vec<&str> = vec!["bar", "baz", "foo"];
 
-    assert_eq!(actual, expected);
-  }
+        assert_eq!(actual, expected);
+    }
 
-  #[test]
-  fn schedule_dependency_duplicates() {
-    let mut tasks1 = HashMap::new();
-    tasks1.insert("foo".to_owned(), empty_task());
-    tasks1.insert("bar".to_owned(), empty_task());
-    tasks1.insert(
-      "baz".to_owned(),
-      task_with_dependencies(vec![
-        "foo".to_owned(),
-        "bar".to_owned(),
-        "foo".to_owned(),
-      ]),
-    );
+    #[test]
+    fn schedule_dependency_duplicates() {
+        let mut tasks1 = HashMap::new();
+        tasks1.insert("foo".to_owned(), empty_task());
+        tasks1.insert("bar".to_owned(), empty_task());
+        tasks1.insert(
+            "baz".to_owned(),
+            task_with_dependencies(vec![
+                "foo".to_owned(),
+                "bar".to_owned(),
+                "foo".to_owned(),
+            ]),
+        );
 
-    let mut tasks2 = HashMap::new();
-    tasks2.insert("foo".to_owned(), empty_task());
-    tasks2.insert("bar".to_owned(), empty_task());
-    tasks2.insert(
-      "baz".to_owned(),
-      task_with_dependencies(vec![
-        "bar".to_owned(),
-        "foo".to_owned(),
-        "bar".to_owned(),
-      ]),
-    );
+        let mut tasks2 = HashMap::new();
+        tasks2.insert("foo".to_owned(), empty_task());
+        tasks2.insert("bar".to_owned(), empty_task());
+        tasks2.insert(
+            "baz".to_owned(),
+            task_with_dependencies(vec![
+                "bar".to_owned(),
+                "foo".to_owned(),
+                "bar".to_owned(),
+            ]),
+        );
 
-    let toastfile1 = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks: tasks1,
-    };
+        let toastfile1 = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks: tasks1,
+        };
 
-    let toastfile2 = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks: tasks2,
-    };
+        let toastfile2 = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks: tasks2,
+        };
 
-    let first: Vec<&str> = compute(&toastfile1, &["baz"]);
-    let second: Vec<&str> = compute(&toastfile2, &["baz"]);
+        let first: Vec<&str> = compute(&toastfile1, &["baz"]);
+        let second: Vec<&str> = compute(&toastfile2, &["baz"]);
 
-    assert_eq!(first, second);
-  }
+        assert_eq!(first, second);
+    }
 
-  #[test]
-  fn schedule_input_duplicates() {
-    let mut tasks = HashMap::new();
-    tasks.insert("foo".to_owned(), empty_task());
-    tasks.insert("bar".to_owned(), empty_task());
-    tasks.insert("baz".to_owned(), empty_task());
+    #[test]
+    fn schedule_input_duplicates() {
+        let mut tasks = HashMap::new();
+        tasks.insert("foo".to_owned(), empty_task());
+        tasks.insert("bar".to_owned(), empty_task());
+        tasks.insert("baz".to_owned(), empty_task());
 
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
 
-    let first: Vec<&str> = compute(&toastfile, &["baz", "bar", "baz"]);
-    let second: Vec<&str> = compute(&toastfile, &["bar", "baz", "bar"]);
+        let first: Vec<&str> = compute(&toastfile, &["baz", "bar", "baz"]);
+        let second: Vec<&str> = compute(&toastfile, &["bar", "baz", "bar"]);
 
-    assert_eq!(first, second);
-  }
+        assert_eq!(first, second);
+    }
 
-  #[test]
-  fn schedule_dependency_order() {
-    let mut tasks1 = HashMap::new();
-    tasks1.insert("foo".to_owned(), empty_task());
-    tasks1.insert("bar".to_owned(), empty_task());
-    tasks1.insert("baz".to_owned(), empty_task());
-    tasks1.insert(
-      "qux".to_owned(),
-      task_with_dependencies(vec![
-        "foo".to_owned(),
-        "bar".to_owned(),
-        "baz".to_owned(),
-      ]),
-    );
+    #[test]
+    fn schedule_dependency_order() {
+        let mut tasks1 = HashMap::new();
+        tasks1.insert("foo".to_owned(), empty_task());
+        tasks1.insert("bar".to_owned(), empty_task());
+        tasks1.insert("baz".to_owned(), empty_task());
+        tasks1.insert(
+            "qux".to_owned(),
+            task_with_dependencies(vec![
+                "foo".to_owned(),
+                "bar".to_owned(),
+                "baz".to_owned(),
+            ]),
+        );
 
-    let mut tasks2 = HashMap::new();
-    tasks2.insert("foo".to_owned(), empty_task());
-    tasks2.insert("bar".to_owned(), empty_task());
-    tasks2.insert("baz".to_owned(), empty_task());
-    tasks2.insert(
-      "qux".to_owned(),
-      task_with_dependencies(vec![
-        "baz".to_owned(),
-        "bar".to_owned(),
-        "foo".to_owned(),
-      ]),
-    );
+        let mut tasks2 = HashMap::new();
+        tasks2.insert("foo".to_owned(), empty_task());
+        tasks2.insert("bar".to_owned(), empty_task());
+        tasks2.insert("baz".to_owned(), empty_task());
+        tasks2.insert(
+            "qux".to_owned(),
+            task_with_dependencies(vec![
+                "baz".to_owned(),
+                "bar".to_owned(),
+                "foo".to_owned(),
+            ]),
+        );
 
-    let toastfile1 = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks: tasks1,
-    };
+        let toastfile1 = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks: tasks1,
+        };
 
-    let toastfile2 = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks: tasks2,
-    };
+        let toastfile2 = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks: tasks2,
+        };
 
-    let first: Vec<&str> = compute(&toastfile1, &["baz"]);
-    let second: Vec<&str> = compute(&toastfile2, &["baz"]);
+        let first: Vec<&str> = compute(&toastfile1, &["baz"]);
+        let second: Vec<&str> = compute(&toastfile2, &["baz"]);
 
-    assert_eq!(first, second);
-  }
+        assert_eq!(first, second);
+    }
 
-  #[test]
-  fn schedule_input_order() {
-    let mut tasks = HashMap::new();
-    tasks.insert("foo".to_owned(), empty_task());
-    tasks.insert("bar".to_owned(), empty_task());
-    tasks.insert("baz".to_owned(), empty_task());
+    #[test]
+    fn schedule_input_order() {
+        let mut tasks = HashMap::new();
+        tasks.insert("foo".to_owned(), empty_task());
+        tasks.insert("bar".to_owned(), empty_task());
+        tasks.insert("baz".to_owned(), empty_task());
 
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
 
-    let first: Vec<&str> = compute(&toastfile, &["foo", "bar", "baz"]);
-    let second: Vec<&str> = compute(&toastfile, &["baz", "bar", "foo"]);
+        let first: Vec<&str> = compute(&toastfile, &["foo", "bar", "baz"]);
+        let second: Vec<&str> = compute(&toastfile, &["baz", "bar", "foo"]);
 
-    assert_eq!(first, second);
-  }
+        assert_eq!(first, second);
+    }
 }

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -2,88 +2,88 @@ use crossbeam::channel::{bounded, Sender};
 use indicatif::{ProgressBar, ProgressStyle};
 use scopeguard::guard;
 use std::{
-  sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-  },
-  thread,
-  thread::sleep,
-  time::{Duration, Instant},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread,
+    thread::sleep,
+    time::{Duration, Instant},
 };
 
 // Render a spinner in the terminal. When the returned value is dropped, the
 // spinner is stopped.
 pub fn spin(message: &str) -> impl Drop {
-  // Start a thread for our spinner-as-a-service. This thread will only be
-  // created once and will live for the duration of the whole program.
-  lazy_static! {
-    static ref SPINNER_SERVICE: Sender<(String, Arc<AtomicBool>, Sender<()>)> = {
-      // Create a channel for requests to start spinning.
-      let (request_sender, request_receiver) =
-        bounded::<(String, Arc<AtomicBool>, Sender<()>)>(0);
+    // Start a thread for our spinner-as-a-service. This thread will only be
+    // created once and will live for the duration of the whole program.
+    lazy_static! {
+      static ref SPINNER_SERVICE: Sender<(String, Arc<AtomicBool>, Sender<()>)> = {
+        // Create a channel for requests to start spinning.
+        let (request_sender, request_receiver) =
+          bounded::<(String, Arc<AtomicBool>, Sender<()>)>(0);
 
-      // Start a thread to handle spinner requests.
-      thread::spawn(move || loop {
-        // Wait for a request. The `unwrap` is safe since we never hang up the
-        // channel.
-        let (message, spinning, response_sender) =
-          request_receiver.recv().unwrap();
+        // Start a thread to handle spinner requests.
+        thread::spawn(move || loop {
+          // Wait for a request. The `unwrap` is safe since we never hang up the
+          // channel.
+          let (message, spinning, response_sender) =
+            request_receiver.recv().unwrap();
 
-        // Create the spinner!
-        let spinner = ProgressBar::new(1);
-        spinner.set_style(ProgressStyle::default_spinner());
-        spinner.set_message(&message);
+          // Create the spinner!
+          let spinner = ProgressBar::new(1);
+          spinner.set_style(ProgressStyle::default_spinner());
+          spinner.set_message(&message);
 
-        // Animate the spinner for as long as necessary.
-        let now = Instant::now();
-        while spinning.load(Ordering::SeqCst) {
-          // Render the next frame of the spinner.
-          spinner.tick();
+          // Animate the spinner for as long as necessary.
+          let now = Instant::now();
+          while spinning.load(Ordering::SeqCst) {
+            // Render the next frame of the spinner.
+            spinner.tick();
 
-          // For the first 100ms, we animate on a shorter time interval so we
-          // can stop faster if the work finishes instantly. If the work takes
-          // longer than that, we slow the animation down out of courtesy for
-          // the CPU.
-          if now.elapsed() < Duration::from_millis(100) {
-            sleep(Duration::from_millis(16));
-          } else {
-            sleep(Duration::from_millis(100));
+            // For the first 100ms, we animate on a shorter time interval so we
+            // can stop faster if the work finishes instantly. If the work takes
+            // longer than that, we slow the animation down out of courtesy for
+            // the CPU.
+            if now.elapsed() < Duration::from_millis(100) {
+              sleep(Duration::from_millis(16));
+            } else {
+              sleep(Duration::from_millis(100));
+            }
           }
-        }
 
-        // Clean up the spinner.
-        spinner.finish_and_clear();
+          // Clean up the spinner.
+          spinner.finish_and_clear();
 
-        // Inform the caller that the spinner has been cleaned up. The `unwrap`
-        // is safe since we never hang up the channel.
-        response_sender.send(()).unwrap();
-      });
+          // Inform the caller that the spinner has been cleaned up. The `unwrap`
+          // is safe since we never hang up the channel.
+          response_sender.send(()).unwrap();
+        });
 
-      // The sender half of the request channel is the API for this spinner
-      // service. Return it.
-      request_sender
-    };
-  }
+        // The sender half of the request channel is the API for this spinner
+        // service. Return it.
+        request_sender
+      };
+    }
 
-  // Create a channel for waiting on the spinner.
-  let (response_sender, response_receiver) = bounded::<()>(0);
+    // Create a channel for waiting on the spinner.
+    let (response_sender, response_receiver) = bounded::<()>(0);
 
-  // This will be set to `false` when it's time to stop the spinner.
-  let spinning = Arc::new(AtomicBool::new(true));
+    // This will be set to `false` when it's time to stop the spinner.
+    let spinning = Arc::new(AtomicBool::new(true));
 
-  // Create and animate the spinner. The `unwrap` is safe since we never hang
-  // up the channel.
-  SPINNER_SERVICE
-    .send((message.to_owned(), spinning.clone(), response_sender))
-    .unwrap();
-
-  // Return a guard that stops the spinner via its destructor.
-  guard((), move |_| {
-    // Tell the spinner service to stop the spinner.
-    spinning.store(false, Ordering::SeqCst);
-
-    // Wait for the spinner to stop. The `unwrap` is safe since we never hang
+    // Create and animate the spinner. The `unwrap` is safe since we never hang
     // up the channel.
-    response_receiver.recv().unwrap();
-  })
+    SPINNER_SERVICE
+        .send((message.to_owned(), spinning.clone(), response_sender))
+        .unwrap();
+
+    // Return a guard that stops the spinner via its destructor.
+    guard((), move |_| {
+        // Tell the spinner service to stop the spinner.
+        spinning.store(false, Ordering::SeqCst);
+
+        // Wait for the spinner to stop. The `unwrap` is safe since we never hang
+        // up the channel.
+        response_receiver.recv().unwrap();
+    })
 }

--- a/src/tar.rs
+++ b/src/tar.rs
@@ -1,215 +1,219 @@
 use crate::{cache, format::CodeStr, spinner::spin};
 use std::{
-  fs::File,
-  io::{empty, Read, Seek, SeekFrom, Write},
-  os::unix::fs::PermissionsExt,
-  path::{Path, PathBuf},
-  sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-  },
+    fs::File,
+    io::{empty, Read, Seek, SeekFrom, Write},
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 use tar::{Builder, EntryType, Header};
 use walkdir::WalkDir;
 
 // Add a file or directory to a tar archive.
 pub fn append<R: Read, W: Write>(
-  builder: &mut Builder<W>,
-  path: &Path,
-  data: R,
-  size: u64,
-  entry_type: EntryType,
-  executable: bool,
+    builder: &mut Builder<W>,
+    path: &Path,
+    data: R,
+    size: u64,
+    entry_type: EntryType,
+    executable: bool,
 ) {
-  // Tar archives must contain only relative paths. But for our purposes, the
-  // paths will be relative to the filesystem root, so we can just strip the
-  // leading `/`. The `unwrap` is safe due to the prefix check.
-  let destination = if path.starts_with("/") {
-    path.strip_prefix("/").unwrap().to_owned()
-  } else {
-    path.to_owned()
-  };
+    // Tar archives must contain only relative paths. But for our purposes, the
+    // paths will be relative to the filesystem root, so we can just strip the
+    // leading `/`. The `unwrap` is safe due to the prefix check.
+    let destination = if path.starts_with("/") {
+        path.strip_prefix("/").unwrap().to_owned()
+    } else {
+        path.to_owned()
+    };
 
-  // If destination is the root path `/`, there is nothing to do. That path
-  // already exists in any file system.
-  if destination.parent().is_none() {
-    return;
-  }
+    // If destination is the root path `/`, there is nothing to do. That path
+    // already exists in any file system.
+    if destination.parent().is_none() {
+        return;
+    }
 
-  // Construct a tar header for this entry.
-  let mut header = Header::new_gnu();
-  header.set_mode(if executable { 0o777 } else { 0o666 });
-  header.set_size(size);
+    // Construct a tar header for this entry.
+    let mut header = Header::new_gnu();
+    header.set_mode(if executable { 0o777 } else { 0o666 });
+    header.set_size(size);
 
-  // Add the entry to the archive.
-  header.set_entry_type(entry_type);
-  builder.append_data(&mut header, destination, data).unwrap();
+    // Add the entry to the archive.
+    header.set_entry_type(entry_type);
+    builder.append_data(&mut header, destination, data).unwrap();
 }
 
 // Construct a tar archive and return a hash of its contents.
 pub fn create<W: Write>(
-  spinner_message: &str,
-  writer: W,
-  input_paths: &[PathBuf],
-  source_dir: &Path,
-  destination_dir: &Path,
-  interrupted: &Arc<AtomicBool>,
+    spinner_message: &str,
+    writer: W,
+    input_paths: &[PathBuf],
+    source_dir: &Path,
+    destination_dir: &Path,
+    interrupted: &Arc<AtomicBool>,
 ) -> Result<(W, String), String> {
-  // Render a spinner animation in the terminal.
-  let _guard = spin(spinner_message);
+    // Render a spinner animation in the terminal.
+    let _guard = spin(spinner_message);
 
-  // Canonicalize the source directory such that other paths can be relativized
-  // with respect to it.
-  let source_dir = source_dir.canonicalize().map_err(|e| {
-    format!(
-      "Unable to canonicalize path {}. Details: {}.",
-      source_dir.to_string_lossy().code_str(),
-      e
-    )
-  })?;
-
-  // This vector will store all the hashes of the contents and metadata of all
-  // the files in the archive. In the end, we will sort this vector and then
-  // take the hash of the whole thing.
-  let mut file_hashes = vec![];
-
-  // This builder will be responsible for writing to the tar file.
-  let mut builder = Builder::new(writer);
-  builder.follow_symlinks(false); // [tag:symlinks]
-
-  // Add `destination_dir` to the archive.
-  append(
-    &mut builder,
-    &destination_dir,
-    empty(),
-    0,
-    EntryType::Directory,
-    true,
-  );
-
-  // Add each path to the archive.
-  for relative_input_path in input_paths {
-    // Compute the source path.
-    let absolute_input_path = source_dir.join(relative_input_path);
-
-    // The path is a directory, so we need to traverse it.
-    for entry in WalkDir::new(&absolute_input_path) {
-      // If the user wants to stop the operation, quit now.
-      if interrupted.load(Ordering::SeqCst) {
-        return Err(super::INTERRUPT_MESSAGE.to_owned());
-      }
-
-      // Unwrap the entry.
-      let entry = entry.map_err(|e| {
+    // Canonicalize the source directory such that other paths can be relativized
+    // with respect to it.
+    let source_dir = source_dir.canonicalize().map_err(|e| {
         format!(
-          "Unable to traverse path {}. Details: {}.",
-          &absolute_input_path.to_string_lossy().code_str(),
-          e
+            "Unable to canonicalize path {}. Details: {}.",
+            source_dir.to_string_lossy().code_str(),
+            e
         )
-      })?;
+    })?;
 
-      // Fetch the metadata for this entry.
-      let entry_metadata = entry.metadata().map_err(|e| {
-        format!(
-          "Unable to fetch filesystem metadata for {}. Details: {}.",
-          &absolute_input_path.to_string_lossy().code_str(),
-          e
-        )
-      })?;
+    // This vector will store all the hashes of the contents and metadata of all
+    // the files in the archive. In the end, we will sort this vector and then
+    // take the hash of the whole thing.
+    let mut file_hashes = vec![];
 
-      // Fetch the host path.
-      let absolute_host_path = entry.path().canonicalize().map_err(|e| {
-        format!(
-          "Unable to canonicalize path {}. Details: {}.",
-          &entry.path().to_string_lossy().code_str(),
-          e
-        )
-      })?;
+    // This builder will be responsible for writing to the tar file.
+    let mut builder = Builder::new(writer);
+    builder.follow_symlinks(false); // [tag:symlinks]
 
-      // Relativize the host path.
-      let relative_path = absolute_host_path
-        .strip_prefix(&source_dir)
-        .map_err(|e| {
-          format!(
+    // Add `destination_dir` to the archive.
+    append(
+        &mut builder,
+        &destination_dir,
+        empty(),
+        0,
+        EntryType::Directory,
+        true,
+    );
+
+    // Add each path to the archive.
+    for relative_input_path in input_paths {
+        // Compute the source path.
+        let absolute_input_path = source_dir.join(relative_input_path);
+
+        // The path is a directory, so we need to traverse it.
+        for entry in WalkDir::new(&absolute_input_path) {
+            // If the user wants to stop the operation, quit now.
+            if interrupted.load(Ordering::SeqCst) {
+                return Err(super::INTERRUPT_MESSAGE.to_owned());
+            }
+
+            // Unwrap the entry.
+            let entry = entry.map_err(|e| {
+                format!(
+                    "Unable to traverse path {}. Details: {}.",
+                    &absolute_input_path.to_string_lossy().code_str(),
+                    e
+                )
+            })?;
+
+            // Fetch the metadata for this entry.
+            let entry_metadata = entry.metadata().map_err(|e| {
+                format!(
+                    "Unable to fetch filesystem metadata for {}. Details: {}.",
+                    &absolute_input_path.to_string_lossy().code_str(),
+                    e
+                )
+            })?;
+
+            // Fetch the host path.
+            let absolute_host_path =
+                entry.path().canonicalize().map_err(|e| {
+                    format!(
+                        "Unable to canonicalize path {}. Details: {}.",
+                        &entry.path().to_string_lossy().code_str(),
+                        e
+                    )
+                })?;
+
+            // Relativize the host path.
+            let relative_path = absolute_host_path
+                .strip_prefix(&source_dir)
+                .map_err(|e| {
+                    format!(
             "Unable to relativize path {} with respect to {}. Details: {}.",
             &entry.path().to_string_lossy().code_str(),
             &source_dir.to_string_lossy().code_str(),
             e
           )
-        })?
-        .to_owned();
+                })?
+                .to_owned();
 
-      // Check the type of the entry. Note that Toast ignores symbolic links.
-      // [ref:symlinks]
-      if entry.file_type().is_file() {
-        // Determine if the file has the executable bit set.
-        let mode = entry_metadata.permissions().mode();
-        let executable = mode & 0o1 > 0 || mode & 0o10 > 0 || mode & 0o100 > 0;
+            // Check the type of the entry. Note that Toast ignores symbolic links.
+            // [ref:symlinks]
+            if entry.file_type().is_file() {
+                // Determine if the file has the executable bit set.
+                let mode = entry_metadata.permissions().mode();
+                let executable =
+                    mode & 0o1 > 0 || mode & 0o10 > 0 || mode & 0o100 > 0;
 
-        // It's a file. Open it so we can compute the hash of its contents.
-        let mut file = File::open(&absolute_host_path).map_err(|e| {
-          format!(
-            "Unable to open file {}. Details: {}.",
-            &absolute_host_path.to_string_lossy().code_str(),
-            e
-          )
-        })?;
+                // It's a file. Open it so we can compute the hash of its contents.
+                let mut file =
+                    File::open(&absolute_host_path).map_err(|e| {
+                        format!(
+                            "Unable to open file {}. Details: {}.",
+                            &absolute_host_path.to_string_lossy().code_str(),
+                            e
+                        )
+                    })?;
 
-        // Compute the hash of the file contents and metadata.
-        file_hashes.push(cache::extend(
-          &cache::extend(
-            &cache::hash_str(&relative_path.to_string_lossy()),
-            &cache::hash_read(&mut file)?,
-          ),
-          if executable { "+x" } else { "-x" },
-        ));
+                // Compute the hash of the file contents and metadata.
+                file_hashes.push(cache::extend(
+                    &cache::extend(
+                        &cache::hash_str(&relative_path.to_string_lossy()),
+                        &cache::hash_read(&mut file)?,
+                    ),
+                    if executable { "+x" } else { "-x" },
+                ));
 
-        // Jump back to the beginning of the file so the tar builder can read it.
-        file.seek(SeekFrom::Start(0)).map_err(|e| {
-          format!(
-            "Unable to seek file {}. Details: {}.",
-            &absolute_host_path.to_string_lossy().code_str(),
-            e
-          )
-        })?;
+                // Jump back to the beginning of the file so the tar builder can read it.
+                file.seek(SeekFrom::Start(0)).map_err(|e| {
+                    format!(
+                        "Unable to seek file {}. Details: {}.",
+                        &absolute_host_path.to_string_lossy().code_str(),
+                        e
+                    )
+                })?;
 
-        // Add the file to the archive and return.
-        append(
-          &mut builder,
-          &destination_dir.join(&relative_path),
-          file,
-          entry_metadata.len(),
-          EntryType::Regular,
-          executable,
-        );
-      } else if entry.file_type().is_dir() {
-        // It's a directory. Only its name is relevant for the cache key.
-        file_hashes.push(cache::hash_str(&relative_path.to_string_lossy()));
+                // Add the file to the archive and return.
+                append(
+                    &mut builder,
+                    &destination_dir.join(&relative_path),
+                    file,
+                    entry_metadata.len(),
+                    EntryType::Regular,
+                    executable,
+                );
+            } else if entry.file_type().is_dir() {
+                // It's a directory. Only its name is relevant for the cache key.
+                file_hashes
+                    .push(cache::hash_str(&relative_path.to_string_lossy()));
 
-        // Add the directory to the archive.
-        append(
-          &mut builder,
-          &destination_dir.join(&relative_path),
-          empty(),
-          0,
-          EntryType::Directory,
-          true,
-        );
-      }
+                // Add the directory to the archive.
+                append(
+                    &mut builder,
+                    &destination_dir.join(&relative_path),
+                    empty(),
+                    0,
+                    EntryType::Directory,
+                    true,
+                );
+            }
+        }
     }
-  }
 
-  // Sort the file hashes to ensure the directory traversal order doesn't
-  // matter.
-  file_hashes.sort();
+    // Sort the file hashes to ensure the directory traversal order doesn't
+    // matter.
+    file_hashes.sort();
 
-  // Return the tar file and the hash of its contents.
-  Ok((
-    builder
-      .into_inner()
-      .map_err(|e| format!("Error writing tar archive. Details: {}.", e))?,
-    file_hashes
-      .iter()
-      .fold(cache::hash_str(""), |acc, x| cache::extend(&acc, x)),
-  ))
+    // Return the tar file and the hash of its contents.
+    Ok((
+        builder.into_inner().map_err(|e| {
+            format!("Error writing tar archive. Details: {}.", e)
+        })?,
+        file_hashes
+            .iter()
+            .fold(cache::hash_str(""), |acc, x| cache::extend(&acc, x)),
+    ))
 }

--- a/src/toastfile.rs
+++ b/src/toastfile.rs
@@ -1,9 +1,9 @@
 use crate::{format, format::CodeStr};
 use serde::{Deserialize, Serialize};
 use std::{
-  collections::{HashMap, HashSet},
-  env,
-  path::{Path, PathBuf},
+    collections::{HashMap, HashSet},
+    env,
+    path::{Path, PathBuf},
 };
 
 // The default location for commands and files copied into the container
@@ -16,433 +16,438 @@ pub const DEFAULT_USER: &str = "root";
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Task {
-  #[serde(default)]
-  pub dependencies: Vec<String>,
+    #[serde(default)]
+    pub dependencies: Vec<String>,
 
-  #[serde(default = "default_task_cache")]
-  pub cache: bool,
+    #[serde(default = "default_task_cache")]
+    pub cache: bool,
 
-  #[serde(default)]
-  pub environment: HashMap<String, Option<String>>,
+    #[serde(default)]
+    pub environment: HashMap<String, Option<String>>,
 
-  #[serde(default = "default_task_watch")]
-  pub watch: bool,
+    #[serde(default = "default_task_watch")]
+    pub watch: bool,
 
-  #[serde(default)]
-  pub input_paths: Vec<PathBuf>,
+    #[serde(default)]
+    pub input_paths: Vec<PathBuf>,
 
-  #[serde(default)]
-  pub output_paths: Vec<PathBuf>,
+    #[serde(default)]
+    pub output_paths: Vec<PathBuf>,
 
-  #[serde(default)]
-  pub ports: Vec<String>,
+    #[serde(default)]
+    pub ports: Vec<String>,
 
-  #[serde(default = "default_task_location")]
-  pub location: PathBuf,
+    #[serde(default = "default_task_location")]
+    pub location: PathBuf,
 
-  #[serde(default = "default_task_user")]
-  pub user: String,
+    #[serde(default = "default_task_user")]
+    pub user: String,
 
-  pub command: Option<String>,
+    pub command: Option<String>,
 }
 
 fn default_task_cache() -> bool {
-  true
+    true
 }
 
 fn default_task_watch() -> bool {
-  false
+    false
 }
 
 fn default_task_location() -> PathBuf {
-  Path::new(DEFAULT_LOCATION).to_owned()
+    Path::new(DEFAULT_LOCATION).to_owned()
 }
 
 fn default_task_user() -> String {
-  DEFAULT_USER.to_owned()
+    DEFAULT_USER.to_owned()
 }
 
 // This struct represents a toastfile.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Toastfile {
-  pub image: String,
-  pub default: Option<String>,
-  pub tasks: HashMap<String, Task>,
+    pub image: String,
+    pub default: Option<String>,
+    pub tasks: HashMap<String, Task>,
 }
 
 // Parse config data.
 pub fn parse(toastfile_data: &str) -> Result<Toastfile, String> {
-  // Deserialize the data.
-  let toastfile: Toastfile =
-    serde_yaml::from_str(toastfile_data).map_err(|e| format!("{}", e))?;
+    // Deserialize the data.
+    let toastfile: Toastfile =
+        serde_yaml::from_str(toastfile_data).map_err(|e| format!("{}", e))?;
 
-  // Make sure the paths are valid.
-  check_paths(&toastfile)?;
+    // Make sure the paths are valid.
+    check_paths(&toastfile)?;
 
-  // Make sure caching is disabled when appropriate.
-  check_caching(&toastfile)?;
+    // Make sure caching is disabled when appropriate.
+    check_caching(&toastfile)?;
 
-  // Make sure the dependencies are valid.
-  check_dependencies(&toastfile)?;
+    // Make sure the dependencies are valid.
+    check_dependencies(&toastfile)?;
 
-  // Return the toastfile.
-  Ok(toastfile)
+    // Return the toastfile.
+    Ok(toastfile)
 }
 
 // Fetch the variables for a task from the environment.
 pub fn environment<'a>(
-  task: &'a Task,
+    task: &'a Task,
 ) -> Result<HashMap<String, String>, Vec<&'a str>> {
-  let mut violations = vec![];
-  let mut result = HashMap::new();
+    let mut violations = vec![];
+    let mut result = HashMap::new();
 
-  for (arg, default) in &task.environment {
-    let maybe_var = env::var(arg);
-    if let Some(default) = default {
-      result
-        .insert(arg.clone(), maybe_var.unwrap_or_else(|_| default.clone()));
-    } else if let Ok(var) = maybe_var {
-      result.insert(arg.clone(), var);
-    } else {
-      violations.push(arg.as_ref());
+    for (arg, default) in &task.environment {
+        let maybe_var = env::var(arg);
+        if let Some(default) = default {
+            result.insert(
+                arg.clone(),
+                maybe_var.unwrap_or_else(|_| default.clone()),
+            );
+        } else if let Ok(var) = maybe_var {
+            result.insert(arg.clone(), var);
+        } else {
+            violations.push(arg.as_ref());
+        }
     }
-  }
 
-  if violations.is_empty() {
-    Ok(result)
-  } else {
-    Err(violations)
-  }
+    if violations.is_empty() {
+        Ok(result)
+    } else {
+        Err(violations)
+    }
 }
 
 // Check that paths that should be relative are, and likewise for paths that
 // should be absolute.
 fn check_paths(toastfile: &Toastfile) -> Result<(), String> {
-  for (name, task) in &toastfile.tasks {
-    // Check `input_paths`.
-    for path in &task.input_paths {
-      if path.is_absolute() {
-        return Err(format!(
-          "Task {} has an absolute {}: {}.",
-          name.code_str(),
-          "input_path".code_str(),
-          path.to_string_lossy().code_str()
-        ));
-      }
+    for (name, task) in &toastfile.tasks {
+        // Check `input_paths`.
+        for path in &task.input_paths {
+            if path.is_absolute() {
+                return Err(format!(
+                    "Task {} has an absolute {}: {}.",
+                    name.code_str(),
+                    "input_path".code_str(),
+                    path.to_string_lossy().code_str()
+                ));
+            }
+        }
+
+        // Check `output_paths`.
+        for path in &task.output_paths {
+            if path.is_absolute() {
+                return Err(format!(
+                    "Task {} has an absolute {}: {}.",
+                    name.code_str(),
+                    "ouput_path".code_str(),
+                    path.to_string_lossy().code_str()
+                ));
+            }
+        }
+
+        // Check `location`.
+        if task.location.is_relative() {
+            return Err(format!(
+                "Task {} has a relative {}: {}.",
+                name.code_str(),
+                "location".code_str(),
+                task.location.to_string_lossy().code_str()
+            ));
+        }
     }
 
-    // Check `output_paths`.
-    for path in &task.output_paths {
-      if path.is_absolute() {
-        return Err(format!(
-          "Task {} has an absolute {}: {}.",
-          name.code_str(),
-          "ouput_path".code_str(),
-          path.to_string_lossy().code_str()
-        ));
-      }
-    }
-
-    // Check `location`.
-    if task.location.is_relative() {
-      return Err(format!(
-        "Task {} has a relative {}: {}.",
-        name.code_str(),
-        "location".code_str(),
-        task.location.to_string_lossy().code_str()
-      ));
-    }
-  }
-
-  Ok(())
+    Ok(())
 }
 
 // Check that caching is disabled when appropriate.
 fn check_caching(toastfile: &Toastfile) -> Result<(), String> {
-  for (name, task) in &toastfile.tasks {
-    // If a task exposes ports, then caching should be disabled.
-    if !&task.ports.is_empty() && task.cache {
-      return Err(format!(
-        "Task {} exposes ports but does not disable caching. \
-         To fix this, set {} for this task.",
-        name.code_str(),
-        "cache: false".code_str(),
-      ));
-    }
+    for (name, task) in &toastfile.tasks {
+        // If a task exposes ports, then caching should be disabled.
+        if !&task.ports.is_empty() && task.cache {
+            return Err(format!(
+                "Task {} exposes ports but does not disable caching. \
+                 To fix this, set {} for this task.",
+                name.code_str(),
+                "cache: false".code_str(),
+            ));
+        }
 
-    // If a task uses file watching, then caching should be disabled.
-    if task.watch && task.cache {
-      return Err(format!(
+        // If a task uses file watching, then caching should be disabled.
+        if task.watch && task.cache {
+            return Err(format!(
         "Task {} watches the filesystem but does not disable caching. \
          To fix this, set {} for this task.",
         name.code_str(),
         "cache: false".code_str(),
       ));
+        }
     }
-  }
 
-  Ok(())
+    Ok(())
 }
 
 // Check that all dependencies exist and form a DAG (no cycles).
 // [tag:tasks_dag]
 fn check_dependencies<'a>(toastfile: &'a Toastfile) -> Result<(), String> {
-  // Check the default task. [tag:valid_default]
-  let valid_default = toastfile
-    .default
-    .as_ref()
-    .map_or(true, |default| toastfile.tasks.contains_key(default));
+    // Check the default task. [tag:valid_default]
+    let valid_default = toastfile
+        .default
+        .as_ref()
+        .map_or(true, |default| toastfile.tasks.contains_key(default));
 
-  // Map from task to vector of invalid dependencies.
-  let mut violations: HashMap<String, Vec<String>> = HashMap::new();
+    // Map from task to vector of invalid dependencies.
+    let mut violations: HashMap<String, Vec<String>> = HashMap::new();
 
-  // Scan for invalid dependencies. [tag:task_valid]
-  for task in toastfile.tasks.keys() {
-    // [ref:task_valid]
-    for dependency in &toastfile.tasks[task].dependencies {
-      if !toastfile.tasks.contains_key(dependency) {
-        violations
-          .entry(task.to_owned())
-          .or_insert_with(|| vec![])
-          .push(dependency.to_owned());
-      }
+    // Scan for invalid dependencies. [tag:task_valid]
+    for task in toastfile.tasks.keys() {
+        // [ref:task_valid]
+        for dependency in &toastfile.tasks[task].dependencies {
+            if !toastfile.tasks.contains_key(dependency) {
+                violations
+                    .entry(task.to_owned())
+                    .or_insert_with(|| vec![])
+                    .push(dependency.to_owned());
+            }
+        }
     }
-  }
 
-  // If there were any invalid dependencies, report them.
-  if !violations.is_empty() {
-    let violations_series = format::series(
-      violations
-        .iter()
-        .map(|(task, dependencies)| {
-          format!(
-            "{} ({})",
-            task.code_str(),
-            format::series(
-              dependencies
+    // If there were any invalid dependencies, report them.
+    if !violations.is_empty() {
+        let violations_series = format::series(
+            violations
                 .iter()
-                .map(|task| format!("{}", task.code_str()))
+                .map(|(task, dependencies)| {
+                    format!(
+                        "{} ({})",
+                        task.code_str(),
+                        format::series(
+                            dependencies
+                                .iter()
+                                .map(|task| format!("{}", task.code_str()))
+                                .collect::<Vec<_>>()
+                                .as_ref()
+                        )
+                    )
+                })
                 .collect::<Vec<_>>()
-                .as_ref()
-            )
-          )
-        })
-        .collect::<Vec<_>>()
-        .as_ref(),
-    );
+                .as_ref(),
+        );
 
-    if valid_default {
-      return Err(format!(
-        "The following tasks have invalid dependencies: {}.",
-        violations_series
-      ));
-    } else {
-      return Err(format!(
+        if valid_default {
+            return Err(format!(
+                "The following tasks have invalid dependencies: {}.",
+                violations_series
+            ));
+        } else {
+            return Err(format!(
         "The default task {} does not exist, and the following tasks have invalid dependencies: {}.",
         toastfile.default.as_ref().unwrap().code_str(), // [ref:valid_default]
         violations_series
       ));
-    }
-  } else if !valid_default {
-    return Err(format!(
-      "The default task {} does not exist.",
-      toastfile.default.as_ref().unwrap().code_str() // [ref:valid_default]
-    ));
-  }
-
-  // Check that the dependencies aren't cyclic.
-  let mut visited: HashSet<&'a str> = HashSet::new();
-  for task in toastfile.tasks.keys() {
-    let mut frontier: Vec<(&'a str, usize)> = vec![(task, 0)];
-    let mut ancestors_set: HashSet<&'a str> = HashSet::new();
-    let mut ancestors_stack: Vec<&'a str> = vec![];
-
-    // Keep going as long as there are more nodes to process.
-    // [tag:toastfile_frontier_nonempty]
-    while !frontier.is_empty() {
-      // Take the top task from the frontier. This is safe due to
-      // [ref:toastfile_frontier_nonempty].
-      let (task, task_depth) = frontier.pop().unwrap();
-
-      // Update the ancestors set and stack.
-      for _ in 0..ancestors_stack.len() - task_depth {
-        // The `unwrap` is safe because `ancestors_stack.len()` is positive in
-        // every iteration of this loop.
-        let task_to_remove = ancestors_stack.pop().unwrap();
-        ancestors_set.remove(task_to_remove);
-      }
-
-      // If this task is an ancestor of itself, we have a cycle. Return an
-      // error.
-      if ancestors_set.contains(task) {
-        let mut cycle_iter = ancestors_stack.iter();
-        cycle_iter.find(|&&x| x == task);
-        let mut cycle = cycle_iter.collect::<Vec<_>>();
-        cycle.push(&task); // [tag:cycle_nonempty]
-        let error_message = if cycle.len() == 1 {
-          format!("{} depends on itself.", cycle[0].code_str())
-        } else if cycle.len() == 2 {
-          format!(
-            "{} and {} depend on each other.",
-            cycle[0].code_str(),
-            cycle[1].code_str()
-          )
-        } else {
-          let mut cycle_dependencies = cycle[1..].to_owned();
-          cycle_dependencies.push(cycle[0]); // [ref:cycle_nonempty]
-          format!(
-            "{}.",
-            format::series(
-              cycle
-                .iter()
-                .zip(cycle_dependencies)
-                .map(|(x, y)| format!(
-                  "{} depends on {}",
-                  x.code_str(),
-                  y.code_str()
-                ))
-                .collect::<Vec<_>>()
-                .as_ref(),
-            )
-          )
-        };
-        return Err(format!("The dependencies are cyclic. {}", error_message));
-      }
-
-      // If we've never seen this task before, add its dependencies to the
-      // frontier.
-      if !visited.contains(task) {
-        visited.insert(task);
-
-        ancestors_set.insert(task);
-        ancestors_stack.push(task);
-
-        for dependency in &toastfile.tasks[task].dependencies {
-          frontier.push((dependency, task_depth + 1));
         }
-      }
+    } else if !valid_default {
+        return Err(format!(
+            "The default task {} does not exist.",
+            toastfile.default.as_ref().unwrap().code_str() // [ref:valid_default]
+        ));
     }
-  }
 
-  // No violations
-  Ok(())
+    // Check that the dependencies aren't cyclic.
+    let mut visited: HashSet<&'a str> = HashSet::new();
+    for task in toastfile.tasks.keys() {
+        let mut frontier: Vec<(&'a str, usize)> = vec![(task, 0)];
+        let mut ancestors_set: HashSet<&'a str> = HashSet::new();
+        let mut ancestors_stack: Vec<&'a str> = vec![];
+
+        // Keep going as long as there are more nodes to process.
+        // [tag:toastfile_frontier_nonempty]
+        while !frontier.is_empty() {
+            // Take the top task from the frontier. This is safe due to
+            // [ref:toastfile_frontier_nonempty].
+            let (task, task_depth) = frontier.pop().unwrap();
+
+            // Update the ancestors set and stack.
+            for _ in 0..ancestors_stack.len() - task_depth {
+                // The `unwrap` is safe because `ancestors_stack.len()` is positive in
+                // every iteration of this loop.
+                let task_to_remove = ancestors_stack.pop().unwrap();
+                ancestors_set.remove(task_to_remove);
+            }
+
+            // If this task is an ancestor of itself, we have a cycle. Return an
+            // error.
+            if ancestors_set.contains(task) {
+                let mut cycle_iter = ancestors_stack.iter();
+                cycle_iter.find(|&&x| x == task);
+                let mut cycle = cycle_iter.collect::<Vec<_>>();
+                cycle.push(&task); // [tag:cycle_nonempty]
+                let error_message = if cycle.len() == 1 {
+                    format!("{} depends on itself.", cycle[0].code_str())
+                } else if cycle.len() == 2 {
+                    format!(
+                        "{} and {} depend on each other.",
+                        cycle[0].code_str(),
+                        cycle[1].code_str()
+                    )
+                } else {
+                    let mut cycle_dependencies = cycle[1..].to_owned();
+                    cycle_dependencies.push(cycle[0]); // [ref:cycle_nonempty]
+                    format!(
+                        "{}.",
+                        format::series(
+                            cycle
+                                .iter()
+                                .zip(cycle_dependencies)
+                                .map(|(x, y)| format!(
+                                    "{} depends on {}",
+                                    x.code_str(),
+                                    y.code_str()
+                                ))
+                                .collect::<Vec<_>>()
+                                .as_ref(),
+                        )
+                    )
+                };
+                return Err(format!(
+                    "The dependencies are cyclic. {}",
+                    error_message
+                ));
+            }
+
+            // If we've never seen this task before, add its dependencies to the
+            // frontier.
+            if !visited.contains(task) {
+                visited.insert(task);
+
+                ancestors_set.insert(task);
+                ancestors_stack.push(task);
+
+                for dependency in &toastfile.tasks[task].dependencies {
+                    frontier.push((dependency, task_depth + 1));
+                }
+            }
+        }
+    }
+
+    // No violations
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-  use crate::toastfile::{
-    check_caching, check_dependencies, check_paths, environment, parse, Task,
-    Toastfile, DEFAULT_LOCATION, DEFAULT_USER,
-  };
-  use std::{collections::HashMap, env, path::Path};
+    use crate::toastfile::{
+        check_caching, check_dependencies, check_paths, environment, parse,
+        Task, Toastfile, DEFAULT_LOCATION, DEFAULT_USER,
+    };
+    use std::{collections::HashMap, env, path::Path};
 
-  #[test]
-  fn parse_empty() {
-    let input = r#"
+    #[test]
+    fn parse_empty() {
+        let input = r#"
 image: encom:os-12
 tasks: {}
     "#
-    .trim();
+        .trim();
 
-    let toastfile = Ok(Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks: HashMap::new(),
-    });
+        let toastfile = Ok(Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks: HashMap::new(),
+        });
 
-    assert_eq!(parse(input), toastfile);
-  }
+        assert_eq!(parse(input), toastfile);
+    }
 
-  #[test]
-  fn parse_minimal_task() {
-    let input = r#"
+    #[test]
+    fn parse_minimal_task() {
+        let input = r#"
 image: encom:os-12
 tasks:
   foo: {}
     "#
-    .trim();
+        .trim();
 
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
 
-    let toastfile = Ok(Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    });
+        let toastfile = Ok(Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        });
 
-    assert_eq!(parse(input), toastfile);
-  }
+        assert_eq!(parse(input), toastfile);
+    }
 
-  #[test]
-  fn parse_valid_default() {
-    let input = r#"
+    #[test]
+    fn parse_valid_default() {
+        let input = r#"
 image: encom:os-12
 default: foo
 tasks:
   foo: {}
     "#
-    .trim();
+        .trim();
 
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
 
-    let toastfile = Ok(Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: Some("foo".to_owned()),
-      tasks,
-    });
+        let toastfile = Ok(Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: Some("foo".to_owned()),
+            tasks,
+        });
 
-    assert_eq!(parse(input), toastfile);
-  }
+        assert_eq!(parse(input), toastfile);
+    }
 
-  #[test]
-  fn parse_invalid_default() {
-    let input = r#"
+    #[test]
+    fn parse_invalid_default() {
+        let input = r#"
 image: encom:os-12
 default: bar
 tasks:
   foo: {}
     "#
-    .trim();
+        .trim();
 
-    let result = parse(input);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("bar"));
-  }
+        let result = parse(input);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("bar"));
+    }
 
-  #[test]
-  fn parse_comprehensive_task() {
-    let input = r#"
+    #[test]
+    fn parse_comprehensive_task() {
+        let input = r#"
 image: encom:os-12
 tasks:
   foo: {}
@@ -471,715 +476,719 @@ tasks:
     user: waldo
     command: wibble
     "#
-    .trim();
-
-    let mut environment = HashMap::new();
-    environment.insert("SPAM".to_owned(), None);
-    environment.insert("HAM".to_owned(), None);
-    environment.insert("EGGS".to_owned(), None);
-
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-    tasks.insert(
-      "bar".to_owned(),
-      Task {
-        dependencies: vec!["foo".to_owned()],
-        cache: false,
-        environment,
-        watch: true,
-        input_paths: vec![
-          Path::new("qux").to_owned(),
-          Path::new("quux").to_owned(),
-          Path::new("quuz").to_owned(),
-        ],
-        output_paths: vec![
-          Path::new("corge").to_owned(),
-          Path::new("grault").to_owned(),
-          Path::new("garply").to_owned(),
-        ],
-        ports: vec!["3000".to_owned(), "3001".to_owned(), "3002".to_owned()],
-        location: Path::new("/code").to_owned(),
-        user: "waldo".to_owned(),
-        command: Some("wibble".to_owned()),
-      },
-    );
-
-    let toastfile = Ok(Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    });
-
-    assert_eq!(parse(input), toastfile);
-  }
-
-  #[test]
-  fn environment_empty() {
-    let task = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: HashMap::new(),
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: None,
-    };
-
-    assert_eq!(environment(&task), Ok(HashMap::new()));
-  }
-
-  #[test]
-  fn environment_default_overridden() {
-    // NOTE: We add an index to the test arg ("foo1", "foo2", ...) to avoid
-    // having parallel tests clobbering environment variables used by other
-    // threads.
-    let mut env_map = HashMap::new();
-    env_map.insert("foo1".to_owned(), Some("bar".to_owned()));
-
-    let task = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: env_map,
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: None,
-    };
-
-    let mut expected = HashMap::new();
-    expected.insert("foo1".to_owned(), "baz".to_owned());
-
-    env::set_var("foo1", "baz");
-    assert_eq!(env::var("foo1"), Ok("baz".to_owned()));
-    assert_eq!(environment(&task), Ok(expected));
-  }
-
-  #[test]
-  fn environment_default_not_overridden() {
-    // NOTE: We add an index to the test arg ("foo1", "foo2", ...) to avoid
-    // having parallel tests clobbering environment variables used by other
-    // threads.
-    let mut env_map = HashMap::new();
-    env_map.insert("foo2".to_owned(), Some("bar".to_owned()));
-
-    let task = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: env_map,
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: None,
-    };
-
-    let mut expected = HashMap::new();
-    expected.insert("foo2".to_owned(), "bar".to_owned());
-
-    env::remove_var("foo2");
-    assert!(env::var("foo2").is_err());
-    assert_eq!(environment(&task), Ok(expected));
-  }
-
-  #[test]
-  fn environment_missing() {
-    // NOTE: We add an index to the test arg ("foo1", "foo2", ...) to avoid
-    // having parallel tests clobbering environment variables used by other
-    // threads.
-    let mut env_map = HashMap::new();
-    env_map.insert("foo3".to_owned(), None);
-
-    let task = Task {
-      dependencies: vec![],
-      cache: true,
-      environment: env_map,
-      watch: false,
-      input_paths: vec![],
-      output_paths: vec![],
-      ports: vec![],
-      location: Path::new(DEFAULT_LOCATION).to_owned(),
-      user: DEFAULT_USER.to_owned(),
-      command: None,
-    };
-
-    env::remove_var("foo3");
-    assert!(env::var("foo3").is_err());
-    let result = environment(&task);
-    assert!(result.is_err());
-    assert_eq!(result.unwrap_err()[0].to_owned(), "foo3");
-  }
-
-  #[test]
-  fn paths_none() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    assert!(check_paths(&toastfile).is_ok());
-  }
-
-  #[test]
-  fn paths_ok() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![Path::new("bar").to_owned()],
-        output_paths: vec![Path::new("baz").to_owned()],
-        ports: vec![],
-        location: Path::new("/qux").to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    assert!(check_paths(&toastfile).is_ok());
-  }
-
-  #[test]
-  fn absolute_input_paths() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![Path::new("/bar").to_owned()],
-        output_paths: vec![Path::new("baz").to_owned()],
-        ports: vec![],
-        location: Path::new("/qux").to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    let result = check_paths(&toastfile);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("/bar"));
-  }
-
-  #[test]
-  fn absolute_output_paths() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![Path::new("bar").to_owned()],
-        output_paths: vec![Path::new("/baz").to_owned()],
-        ports: vec![],
-        location: Path::new("/qux").to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    let result = check_paths(&toastfile);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("/baz"));
-  }
-
-  #[test]
-  fn relative_location() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![Path::new("bar").to_owned()],
-        output_paths: vec![Path::new("baz").to_owned()],
-        ports: vec![],
-        location: Path::new("qux").to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    let result = check_paths(&toastfile);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("qux"));
-  }
-
-  #[test]
-  fn caching_enabled_with_no_ports_no_watch() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    assert!(check_caching(&toastfile).is_ok());
-  }
-
-  #[test]
-  fn caching_enabled_with_ports() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec!["3000:80".to_owned()],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    let result = check_caching(&toastfile);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("caching"));
-  }
-
-  #[test]
-  fn caching_disabled_with_ports() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: false,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec!["3000:80".to_owned()],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    assert!(check_caching(&toastfile).is_ok());
-  }
-
-  #[test]
-  fn caching_enabled_with_watch() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: true,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    let result = check_caching(&toastfile);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("watches"));
-  }
-
-  #[test]
-  fn caching_disabled_with_watch() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: false,
-        environment: HashMap::new(),
-        watch: true,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec!["3000:80".to_owned()],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    assert!(check_caching(&toastfile).is_ok());
-  }
-
-  #[test]
-  fn check_dependencies_empty() {
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks: HashMap::new(),
-    };
-
-    assert!(check_dependencies(&toastfile).is_ok());
-  }
-
-  #[test]
-  fn check_dependencies_single() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    assert!(check_dependencies(&toastfile).is_ok());
-  }
-
-  #[test]
-  fn check_dependencies_nonempty() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-    tasks.insert(
-      "bar".to_owned(),
-      Task {
-        dependencies: vec!["foo".to_owned()],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    assert!(check_dependencies(&toastfile).is_ok());
-  }
-
-  #[test]
-  fn check_dependencies_nonexistent() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec![],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-    tasks.insert(
-      "bar".to_owned(),
-      Task {
-        dependencies: vec!["foo".to_owned(), "baz".to_owned()],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    let result = check_dependencies(&toastfile);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("baz"));
-  }
-
-  #[test]
-  fn check_dependencies_cycle_1() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec!["foo".to_owned()],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    let result = check_dependencies(&toastfile);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("cyclic"));
-  }
-
-  #[test]
-  fn check_dependencies_cycle_2() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec!["bar".to_owned()],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-    tasks.insert(
-      "bar".to_owned(),
-      Task {
-        dependencies: vec!["foo".to_owned()],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    let result = check_dependencies(&toastfile);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("cyclic"));
-  }
-
-  #[test]
-  fn check_dependencies_cycle_3() {
-    let mut tasks = HashMap::new();
-    tasks.insert(
-      "foo".to_owned(),
-      Task {
-        dependencies: vec!["baz".to_owned()],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-    tasks.insert(
-      "bar".to_owned(),
-      Task {
-        dependencies: vec!["foo".to_owned()],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-    tasks.insert(
-      "baz".to_owned(),
-      Task {
-        dependencies: vec!["bar".to_owned()],
-        cache: true,
-        environment: HashMap::new(),
-        watch: false,
-        input_paths: vec![],
-        output_paths: vec![],
-        ports: vec![],
-        location: Path::new(DEFAULT_LOCATION).to_owned(),
-        user: DEFAULT_USER.to_owned(),
-        command: None,
-      },
-    );
-
-    let toastfile = Toastfile {
-      image: "encom:os-12".to_owned(),
-      default: None,
-      tasks,
-    };
-
-    let result = check_dependencies(&toastfile);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("cyclic"));
-  }
+        .trim();
+
+        let mut environment = HashMap::new();
+        environment.insert("SPAM".to_owned(), None);
+        environment.insert("HAM".to_owned(), None);
+        environment.insert("EGGS".to_owned(), None);
+
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+        tasks.insert(
+            "bar".to_owned(),
+            Task {
+                dependencies: vec!["foo".to_owned()],
+                cache: false,
+                environment,
+                watch: true,
+                input_paths: vec![
+                    Path::new("qux").to_owned(),
+                    Path::new("quux").to_owned(),
+                    Path::new("quuz").to_owned(),
+                ],
+                output_paths: vec![
+                    Path::new("corge").to_owned(),
+                    Path::new("grault").to_owned(),
+                    Path::new("garply").to_owned(),
+                ],
+                ports: vec![
+                    "3000".to_owned(),
+                    "3001".to_owned(),
+                    "3002".to_owned(),
+                ],
+                location: Path::new("/code").to_owned(),
+                user: "waldo".to_owned(),
+                command: Some("wibble".to_owned()),
+            },
+        );
+
+        let toastfile = Ok(Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        });
+
+        assert_eq!(parse(input), toastfile);
+    }
+
+    #[test]
+    fn environment_empty() {
+        let task = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: HashMap::new(),
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: None,
+        };
+
+        assert_eq!(environment(&task), Ok(HashMap::new()));
+    }
+
+    #[test]
+    fn environment_default_overridden() {
+        // NOTE: We add an index to the test arg ("foo1", "foo2", ...) to avoid
+        // having parallel tests clobbering environment variables used by other
+        // threads.
+        let mut env_map = HashMap::new();
+        env_map.insert("foo1".to_owned(), Some("bar".to_owned()));
+
+        let task = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: env_map,
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: None,
+        };
+
+        let mut expected = HashMap::new();
+        expected.insert("foo1".to_owned(), "baz".to_owned());
+
+        env::set_var("foo1", "baz");
+        assert_eq!(env::var("foo1"), Ok("baz".to_owned()));
+        assert_eq!(environment(&task), Ok(expected));
+    }
+
+    #[test]
+    fn environment_default_not_overridden() {
+        // NOTE: We add an index to the test arg ("foo1", "foo2", ...) to avoid
+        // having parallel tests clobbering environment variables used by other
+        // threads.
+        let mut env_map = HashMap::new();
+        env_map.insert("foo2".to_owned(), Some("bar".to_owned()));
+
+        let task = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: env_map,
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: None,
+        };
+
+        let mut expected = HashMap::new();
+        expected.insert("foo2".to_owned(), "bar".to_owned());
+
+        env::remove_var("foo2");
+        assert!(env::var("foo2").is_err());
+        assert_eq!(environment(&task), Ok(expected));
+    }
+
+    #[test]
+    fn environment_missing() {
+        // NOTE: We add an index to the test arg ("foo1", "foo2", ...) to avoid
+        // having parallel tests clobbering environment variables used by other
+        // threads.
+        let mut env_map = HashMap::new();
+        env_map.insert("foo3".to_owned(), None);
+
+        let task = Task {
+            dependencies: vec![],
+            cache: true,
+            environment: env_map,
+            watch: false,
+            input_paths: vec![],
+            output_paths: vec![],
+            ports: vec![],
+            location: Path::new(DEFAULT_LOCATION).to_owned(),
+            user: DEFAULT_USER.to_owned(),
+            command: None,
+        };
+
+        env::remove_var("foo3");
+        assert!(env::var("foo3").is_err());
+        let result = environment(&task);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err()[0].to_owned(), "foo3");
+    }
+
+    #[test]
+    fn paths_none() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        assert!(check_paths(&toastfile).is_ok());
+    }
+
+    #[test]
+    fn paths_ok() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![Path::new("bar").to_owned()],
+                output_paths: vec![Path::new("baz").to_owned()],
+                ports: vec![],
+                location: Path::new("/qux").to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        assert!(check_paths(&toastfile).is_ok());
+    }
+
+    #[test]
+    fn absolute_input_paths() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![Path::new("/bar").to_owned()],
+                output_paths: vec![Path::new("baz").to_owned()],
+                ports: vec![],
+                location: Path::new("/qux").to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        let result = check_paths(&toastfile);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("/bar"));
+    }
+
+    #[test]
+    fn absolute_output_paths() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![Path::new("bar").to_owned()],
+                output_paths: vec![Path::new("/baz").to_owned()],
+                ports: vec![],
+                location: Path::new("/qux").to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        let result = check_paths(&toastfile);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("/baz"));
+    }
+
+    #[test]
+    fn relative_location() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![Path::new("bar").to_owned()],
+                output_paths: vec![Path::new("baz").to_owned()],
+                ports: vec![],
+                location: Path::new("qux").to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        let result = check_paths(&toastfile);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("qux"));
+    }
+
+    #[test]
+    fn caching_enabled_with_no_ports_no_watch() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        assert!(check_caching(&toastfile).is_ok());
+    }
+
+    #[test]
+    fn caching_enabled_with_ports() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec!["3000:80".to_owned()],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        let result = check_caching(&toastfile);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("caching"));
+    }
+
+    #[test]
+    fn caching_disabled_with_ports() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: false,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec!["3000:80".to_owned()],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        assert!(check_caching(&toastfile).is_ok());
+    }
+
+    #[test]
+    fn caching_enabled_with_watch() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: true,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        let result = check_caching(&toastfile);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("watches"));
+    }
+
+    #[test]
+    fn caching_disabled_with_watch() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: false,
+                environment: HashMap::new(),
+                watch: true,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec!["3000:80".to_owned()],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        assert!(check_caching(&toastfile).is_ok());
+    }
+
+    #[test]
+    fn check_dependencies_empty() {
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks: HashMap::new(),
+        };
+
+        assert!(check_dependencies(&toastfile).is_ok());
+    }
+
+    #[test]
+    fn check_dependencies_single() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        assert!(check_dependencies(&toastfile).is_ok());
+    }
+
+    #[test]
+    fn check_dependencies_nonempty() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+        tasks.insert(
+            "bar".to_owned(),
+            Task {
+                dependencies: vec!["foo".to_owned()],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        assert!(check_dependencies(&toastfile).is_ok());
+    }
+
+    #[test]
+    fn check_dependencies_nonexistent() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec![],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+        tasks.insert(
+            "bar".to_owned(),
+            Task {
+                dependencies: vec!["foo".to_owned(), "baz".to_owned()],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        let result = check_dependencies(&toastfile);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("baz"));
+    }
+
+    #[test]
+    fn check_dependencies_cycle_1() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec!["foo".to_owned()],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        let result = check_dependencies(&toastfile);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("cyclic"));
+    }
+
+    #[test]
+    fn check_dependencies_cycle_2() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec!["bar".to_owned()],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+        tasks.insert(
+            "bar".to_owned(),
+            Task {
+                dependencies: vec!["foo".to_owned()],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        let result = check_dependencies(&toastfile);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("cyclic"));
+    }
+
+    #[test]
+    fn check_dependencies_cycle_3() {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "foo".to_owned(),
+            Task {
+                dependencies: vec!["baz".to_owned()],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+        tasks.insert(
+            "bar".to_owned(),
+            Task {
+                dependencies: vec!["foo".to_owned()],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+        tasks.insert(
+            "baz".to_owned(),
+            Task {
+                dependencies: vec!["bar".to_owned()],
+                cache: true,
+                environment: HashMap::new(),
+                watch: false,
+                input_paths: vec![],
+                output_paths: vec![],
+                ports: vec![],
+                location: Path::new(DEFAULT_LOCATION).to_owned(),
+                user: DEFAULT_USER.to_owned(),
+                command: None,
+            },
+        );
+
+        let toastfile = Toastfile {
+            image: "encom:os-12".to_owned(),
+            default: None,
+            tasks,
+        };
+
+        let result = check_dependencies(&toastfile);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("cyclic"));
+    }
 }


### PR DESCRIPTION
Use 4 spaces instead of 2 and wordsmith the README. Personally, I think 4 spaces is a bit gratuitous—it takes up my whole terminal unless I make the font tiny! But sticking to the Rust convention is more important than my personal misgivings. :)