### PR TITLE
Use a custom error type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ services: docker
 install:
   - |
     if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-      echo "$DOCKER_HUB_PASSWORD" | docker login --username stephanmisc --password-stdin
+      echo "$DOCKER_HUB_PASSWORD" |
+        docker login --username stephanmisc --password-stdin
     fi
-  - curl https://raw.githubusercontent.com/stepchowfun/toast/master/install.sh -LSfs | VERSION=0.18.0 sh
+  - curl https://raw.githubusercontent.com/stepchowfun/toast/master/install.sh -LSfs |
+      VERSION=0.18.0 sh
 script:
   - |
     if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then

--- a/install.sh
+++ b/install.sh
@@ -48,12 +48,14 @@
   fi
 
   # Download the binary.
-  if ! curl "https://github.com/stepchowfun/toast/releases/download/$RELEASE/$FILENAME" -o "$FILENAME" -LSf; then
+  if ! curl "https://github.com/stepchowfun/toast/releases/download/$RELEASE/$FILENAME" \
+      -o "$FILENAME" -LSf; then
     fail 'There was an error downloading the binary.'
   fi
 
   # Download the checksum.
-  if ! curl "https://github.com/stepchowfun/toast/releases/download/$RELEASE/$FILENAME.sha256" -o "$FILENAME.sha256" -LSf; then
+  if ! curl "https://github.com/stepchowfun/toast/releases/download/$RELEASE/$FILENAME.sha256" \
+      -o "$FILENAME.sha256" -LSf; then
     fail 'There was an error downloading the checksum.'
   fi
 
@@ -69,7 +71,9 @@
 
   # Install it at the requested destination.
   # shellcheck disable=SC2024
-  mv "$FILENAME" "$DESTINATION" 2> /dev/null || sudo mv "$FILENAME" "$DESTINATION" < /dev/tty || fail "Unable to install the binary at $DESTINATION."
+  mv "$FILENAME" "$DESTINATION" 2> /dev/null ||
+    sudo mv "$FILENAME" "$DESTINATION" < /dev/tty ||
+    fail "Unable to install the binary at $DESTINATION."
 
   # Remove the temporary directory.
   cd ..

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This script runs the integration tests. The `TOAST` environment variable
-# should be set to the absolute path of the Toast binary.
+# This script runs the integration tests. The `TOAST` environment variable should be set to the
+# absolute path of the Toast binary.
 
 # Log the path to the binary.
 echo "Toast location: $TOAST"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,0 @@
-max_width = 79
-hard_tabs = false
-tab_spaces = 4

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::failure::{user_error, Failure};
 use serde::{Deserialize, Serialize};
 
 pub const REPO_DEFAULT: &str = "toast";
@@ -44,8 +45,8 @@ fn default_write_remote_cache() -> bool {
 }
 
 // Parse a program configuration.
-pub fn parse(config: &str) -> Result<Config, String> {
-    serde_yaml::from_str(config).map_err(|e| format!("{}", e))
+pub fn parse(config: &str) -> Result<Config, Failure> {
+    serde_yaml::from_str(config).map_err(user_error("Syntax error."))
 }
 
 #[cfg(test)]
@@ -54,15 +55,15 @@ mod tests {
 
     #[test]
     fn parse_empty() {
-        let result = Ok(Config {
+        let result = Config {
             docker_repo: "toast".to_owned(),
             read_local_cache: true,
             write_local_cache: true,
             read_remote_cache: false,
             write_remote_cache: false,
-        });
+        };
 
-        assert_eq!(parse(EMPTY_CONFIG), result);
+        assert_eq!(parse(EMPTY_CONFIG).unwrap(), result);
     }
 
     #[test]
@@ -76,14 +77,14 @@ write_remote_cache: true
     "#
         .trim();
 
-        let result = Ok(Config {
+        let result = Config {
             docker_repo: "foo".to_owned(),
             read_local_cache: false,
             write_local_cache: false,
             read_remote_cache: true,
             write_remote_cache: true,
-        });
+        };
 
-        assert_eq!(parse(config), result);
+        assert_eq!(parse(config).unwrap(), result);
     }
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,4 +1,8 @@
-use crate::{format::CodeStr, spinner::spin};
+use crate::{
+    failure::{system_error, Failure},
+    format::CodeStr,
+    spinner::spin,
+};
 use std::{
     fs::{create_dir_all, metadata, rename},
     io,
@@ -24,33 +28,25 @@ pub fn random_tag() -> String {
 }
 
 // Query whether an image exists locally.
-pub fn image_exists(
-    image: &str,
-    interrupted: &Arc<AtomicBool>,
-) -> Result<bool, String> {
+pub fn image_exists(image: &str, interrupted: &Arc<AtomicBool>) -> Result<bool, Failure> {
     debug!("Checking existence of image {}\u{2026}", image.code_str());
-    if let Err(e) = run_quiet(
+
+    match run_quiet(
         "Checking existence of image\u{2026}",
         "The image doesn't exist.",
         &["image", "inspect", image],
         interrupted,
     ) {
-        if interrupted.load(Ordering::SeqCst) {
-            Err(e)
-        } else {
-            Ok(false)
-        }
-    } else {
-        Ok(true)
+        Ok(_) => Ok(true),
+        Err(Failure::Interrupted) => Err(Failure::Interrupted),
+        Err(Failure::System(_, _)) | Err(Failure::User(_, _)) => Ok(false),
     }
 }
 
 // Push an image.
-pub fn push_image(
-    image: &str,
-    interrupted: &Arc<AtomicBool>,
-) -> Result<(), String> {
+pub fn push_image(image: &str, interrupted: &Arc<AtomicBool>) -> Result<(), Failure> {
     debug!("Pushing image {}\u{2026}", image.code_str());
+
     run_quiet(
         "Pushing image\u{2026}",
         "Unable to push image.",
@@ -61,11 +57,9 @@ pub fn push_image(
 }
 
 // Pull an image.
-pub fn pull_image(
-    image: &str,
-    interrupted: &Arc<AtomicBool>,
-) -> Result<(), String> {
+pub fn pull_image(image: &str, interrupted: &Arc<AtomicBool>) -> Result<(), Failure> {
     debug!("Pulling image {}\u{2026}", image.code_str());
+
     run_quiet(
         "Pulling image\u{2026}",
         "Unable to pull image.",
@@ -76,11 +70,9 @@ pub fn pull_image(
 }
 
 // Delete an image.
-pub fn delete_image(
-    image: &str,
-    interrupted: &Arc<AtomicBool>,
-) -> Result<(), String> {
+pub fn delete_image(image: &str, interrupted: &Arc<AtomicBool>) -> Result<(), Failure> {
     debug!("Deleting image {}\u{2026}", image.code_str());
+
     run_quiet(
         "Deleting image\u{2026}",
         "Unable to delete image.",
@@ -95,18 +87,17 @@ pub fn create_container(
     image: &str,
     ports: &[String],
     interrupted: &Arc<AtomicBool>,
-) -> Result<String, String> {
+) -> Result<String, Failure> {
     debug!("Creating container from image {}\u{2026}", image.code_str(),);
 
-    // Why `--init`? (1) PID 1 is supposed to reap orphaned zombie processes,
-    // otherwise they can accumulate. Bash does this, but we run `/bin/sh` in the
-    // container, which may or may not be Bash. So `--init` runs Tini
-    // (https://github.com/krallin/tini) as PID 1, which properly reaps orphaned
-    // zombies. (2) PID 1 also does not exhibit the default behavior (crashing)
-    // for signals like SIGINT and SIGTERM. However, PID 1 can still handle these
-    // signals by explicitly trapping them. Tini traps these signals and forwards
-    // them to the child process. Then the default signal handling behavior of
-    // the child process (in our case, `/bin/sh`) works normally. [tag:--init]
+    // Why `--init`? (1) PID 1 is supposed to reap orphaned zombie processes, otherwise they can
+    // accumulate. Bash does this, but we run `/bin/sh` in the container, which may or may not be
+    // Bash. So `--init` runs Tini (https://github.com/krallin/tini) as PID 1, which properly reaps
+    // orphaned zombies. (2) PID 1 also does not exhibit the default behavior (crashing) for signals
+    // like SIGINT and SIGTERM. However, PID 1 can still handle these signals by explicitly trapping
+    // them. Tini traps these signals and forwards them to the child process. Then the default
+    // signal handling behavior of the child process (in our case, `/bin/sh`) works normally.
+    // [tag:--init]
     let mut command = vec!["container", "create", "--init", "--interactive"];
 
     for port in ports {
@@ -130,22 +121,19 @@ pub fn copy_into_container<R: Read>(
     container: &str,
     mut tar: R,
     interrupted: &Arc<AtomicBool>,
-) -> Result<(), String> {
+) -> Result<(), Failure> {
     debug!(
         "Copying files into container {}\u{2026}",
         container.code_str()
     );
+
     run_quiet_stdin(
         "Copying files into container\u{2026}",
         "Unable to copy files into the container.",
         &["container", "cp", "-", &format!("{}:{}", container, "/")],
         |mut stdin| {
-            io::copy(&mut tar, &mut stdin).map_err(|e| {
-                format!(
-                    "Unable to copy files into the container. Details: {}.",
-                    e
-                )
-            })?;
+            io::copy(&mut tar, &mut stdin)
+                .map_err(system_error("Unable to copy files into the container."))?;
 
             Ok(())
         },
@@ -161,7 +149,7 @@ pub fn copy_from_container(
     source_dir: &Path,
     destination_dir: &Path,
     interrupted: &Arc<AtomicBool>,
-) -> Result<(), String> {
+) -> Result<(), Failure> {
     // Copy each path from the container to the host.
     for path in paths {
         debug!(
@@ -170,20 +158,16 @@ pub fn copy_from_container(
             container.code_str()
         );
 
-        // `docker container cp` is not idempotent. For example, suppose there is a
-        // directory called `/foo` in the container and `/bar` does not exist on
-        // the host. Consider the following command:
+        // `docker container cp` is not idempotent. For example, suppose there is a directory called
+        // `/foo` in the container and `/bar` does not exist on the host. Consider the following
+        // command:
         //   `docker cp container:/foo /bar`
-        // The first time that command is run, Docker will create the directory
-        // `/bar` on the host and copy the files from `/foo` into it. But if you
-        // run it again, Docker will copy `/bar` into the directory `/foo`,
-        // resulting in `/foo/foo`, which is undesirable. To work around this, we
-        // first copy the path from the container into a temporary directory (where
-        // the target path is guaranteed to not exist). Then we copy/move that to
-        // the final destination.
-        let temp_dir = tempdir().map_err(|e| {
-            format!("Unable to create temporary directory. Details: {}.", e)
-        })?;
+        // The first time that command is run, Docker will create the directory `/bar` on the host
+        // and copy the files from `/foo` into it. But if you run it again, Docker will copy `/bar`
+        // into the directory `/foo`, resulting in `/foo/foo`, which is undesirable. To work around
+        // this, we first copy the path from the container into a temporary directory (where the
+        // target path is guaranteed to not exist). Then we copy/move that to the final destination.
+        let temp_dir = tempdir().map_err(system_error("Unable to create temporary directory."))?;
 
         // Figure out what needs to go where.
         let source = source_dir.join(path);
@@ -205,74 +189,58 @@ pub fn copy_from_container(
         .map(|_| ())?;
 
         // Check if what we got from the container is a file or a directory.
-        let metadata_err_map = |e| {
-            format!(
-        "Unable to retrieve filesystem metadata for path {}. Details: {}.",
-        intermediate.to_string_lossy().code_str(),
-        e
-      )
-        };
-        if metadata(&intermediate).map_err(metadata_err_map)?.is_file() {
-            // It's a file. Determine the destination directory. The `unwrap` is safe
-            // because the root of the filesystem cannot be a file.
+        if metadata(&intermediate)
+            .map_err(system_error(&format!(
+                "Unable to retrieve filesystem metadata for path {}.",
+                intermediate.to_string_lossy().code_str(),
+            )))?
+            .is_file()
+        {
+            // It's a file. Determine the destination directory. The `unwrap` is safe because the
+            // root of the filesystem cannot be a file.
             let destination_dir = destination.parent().unwrap().to_owned();
 
             // Make sure the destination directory exists.
-            create_dir_all(&destination_dir).map_err(|e| {
-                format!(
-                    "Unable to create directory {}. Details: {}.",
-                    destination_dir.to_string_lossy().code_str(),
-                    e
-                )
-            })?;
+            create_dir_all(&destination_dir).map_err(system_error(&format!(
+                "Unable to create directory {}.",
+                destination_dir.to_string_lossy().code_str(),
+            )))?;
 
             // Move it to the destination.
-            rename(&intermediate, &destination).map_err(|e| {
-                format!(
-                    "Unable to move file {} to destination {}. Details: {}.",
-                    intermediate.to_string_lossy().code_str(),
-                    destination.to_string_lossy().code_str(),
-                    e
-                )
-            })?;
+            rename(&intermediate, &destination).map_err(system_error(&format!(
+                "Unable to move file {} to destination {}.",
+                intermediate.to_string_lossy().code_str(),
+                destination.to_string_lossy().code_str(),
+            )))?;
         } else {
             // It's a directory. Traverse it.
             for entry in WalkDir::new(&intermediate) {
                 // If we run into an error traversing the filesystem, report it.
-                let entry = entry.map_err(|e| {
-                    format!(
-                        "Unable to traverse directory {}. Details: {}.",
-                        intermediate.to_string_lossy().code_str(),
-                        e
-                    )
-                })?;
+                let entry = entry.map_err(system_error(&format!(
+                    "Unable to traverse directory {}.",
+                    intermediate.to_string_lossy().code_str(),
+                )))?;
 
-                // Figure out what needs to go where. The `unwrap` is safe because
-                // `entry` is guaranteed to be inside `intermediate` (or equal to it).
+                // Figure out what needs to go where. The `unwrap` is safe because `entry` is
+                // guaranteed to be inside `intermediate` (or equal to it).
                 let entry_path = entry.path();
-                let destination_path = destination
-                    .join(entry_path.strip_prefix(&intermediate).unwrap());
+                let destination_path =
+                    destination.join(entry_path.strip_prefix(&intermediate).unwrap());
 
                 // Check if the current entry is a file or a directory.
                 if entry.file_type().is_dir() {
                     // It's a directory. Create a directory at the destination.
-                    create_dir_all(&destination_path).map_err(|e| {
-                        format!(
-                            "Unable to create directory {}. Details: {}.",
-                            destination_path.to_string_lossy().code_str(),
-                            e
-                        )
-                    })?;
+                    create_dir_all(&destination_path).map_err(system_error(&format!(
+                        "Unable to create directory {}.",
+                        destination_path.to_string_lossy().code_str(),
+                    )))?;
                 } else {
                     // It's a file. Move it to the destination.
-                    rename(entry_path, &destination_path).map_err(|e| {
-                        format!(
-              "Unable to move file {} to destination {}. Details: {}.",
-              entry_path.to_string_lossy().code_str(),
-              destination_path.to_string_lossy().code_str(),
-              e
-            )
-                    })?;
+                    rename(entry_path, &destination_path).map_err(system_error(&format!(
+                        "Unable to move file {} to destination {}.",
+                        entry_path.to_string_lossy().code_str(),
+                        destination_path.to_string_lossy().code_str(),
+                    )))?;
                 }
             }
         }
@@ -286,19 +254,17 @@ pub fn start_container(
     container: &str,
     command: &str,
     interrupted: &Arc<AtomicBool>,
-) -> Result<(), String> {
+) -> Result<(), Failure> {
     debug!("Starting container {}\u{2026}", container.code_str());
+
     run_loud_stdin(
         "Unable to start container.",
         &["container", "start", "--attach", "--interactive", container],
         |stdin| {
-            write!(stdin, "{}", command).map_err(|e| {
-                format!(
-                    "Unable to send command {} to the container. Details: {}.",
-                    command.code_str(),
-                    e
-                )
-            })?;
+            write!(stdin, "{}", command).map_err(system_error(&format!(
+                "Unable to send command {} to the container.",
+                command.code_str(),
+            )))?;
 
             Ok(())
         },
@@ -308,11 +274,9 @@ pub fn start_container(
 }
 
 // Stop a container.
-pub fn stop_container(
-    container: &str,
-    interrupted: &Arc<AtomicBool>,
-) -> Result<(), String> {
+pub fn stop_container(container: &str, interrupted: &Arc<AtomicBool>) -> Result<(), Failure> {
     debug!("Stopping container {}\u{2026}", container.code_str());
+
     run_quiet(
         "Stopping container\u{2026}",
         "Unable to stop container.",
@@ -327,12 +291,13 @@ pub fn commit_container(
     container: &str,
     image: &str,
     interrupted: &Arc<AtomicBool>,
-) -> Result<(), String> {
+) -> Result<(), Failure> {
     debug!(
         "Committing container {} to image {}\u{2026}",
         container.code_str(),
         image.code_str()
     );
+
     run_quiet(
         "Committing container\u{2026}",
         "Unable to commit container.",
@@ -343,11 +308,9 @@ pub fn commit_container(
 }
 
 // Delete a container.
-pub fn delete_container(
-    container: &str,
-    interrupted: &Arc<AtomicBool>,
-) -> Result<(), String> {
+pub fn delete_container(container: &str, interrupted: &Arc<AtomicBool>) -> Result<(), Failure> {
     debug!("Deleting container {}\u{2026}", container.code_str());
+
     run_quiet(
         "Deleting container\u{2026}",
         "Unable to delete container.",
@@ -358,14 +321,12 @@ pub fn delete_container(
 }
 
 // Run an interactive shell.
-pub fn spawn_shell(
-    image: &str,
-    interrupted: &Arc<AtomicBool>,
-) -> Result<(), String> {
+pub fn spawn_shell(image: &str, interrupted: &Arc<AtomicBool>) -> Result<(), Failure> {
     debug!(
         "Spawning an interactive shell for image {}\u{2026}",
         image.code_str()
     );
+
     run_attach(
         "The shell exited with a failure.",
         &[
@@ -382,148 +343,182 @@ pub fn spawn_shell(
     )
 }
 
-// Run a command, forward its standard error stream, and return its standard
-// output.
+// Run a command, forward its standard error stream, and return its standard output.
 fn run_quiet(
     spinner_message: &str,
     error: &str,
     args: &[&str],
     interrupted: &Arc<AtomicBool>,
-) -> Result<String, String> {
+) -> Result<String, Failure> {
+    // Render a spinner animation and clear it when we're done.
     let _guard = spin(spinner_message);
 
-    let output = command(args).stdin(Stdio::null()).output().map_err(|e| {
-        format!(
-            "{} Perhaps you don't have Docker installed. Details: {}.",
-            error, e
-        )
-    })?;
+    // This is used to determine whether the user interrupted the program during the execution of
+    // the child process.
+    let was_interrupted = interrupted.load(Ordering::SeqCst);
 
+    // Run the child process.
+    let output = command(args)
+        .stdin(Stdio::null())
+        .output()
+        .map_err(system_error(&format!(
+            "{} Perhaps you don't have Docker installed.",
+            error
+        )))?;
+
+    // Handle the result.
     if output.status.success() {
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
     } else {
-        Err(if output.status.code().is_none() {
-            interrupted.store(true, Ordering::SeqCst);
-            super::INTERRUPT_MESSAGE.to_owned()
-        } else {
-            format!(
-                "{} Details:\n{}",
-                error,
-                String::from_utf8_lossy(&output.stderr)
-            )
-        })
+        Err(
+            if output.status.code().is_none()
+                || (!was_interrupted && interrupted.load(Ordering::SeqCst))
+            {
+                interrupted.store(true, Ordering::SeqCst);
+                Failure::Interrupted
+            } else {
+                Failure::System(
+                    format!(
+                        "{} Details:\n{}",
+                        error,
+                        String::from_utf8_lossy(&output.stderr)
+                    ),
+                    None,
+                )
+            },
+        )
     }
 }
 
-// Run a command, forward its standard error stream, and return its standard
-// output. Accepts a closure which receives a pipe to the standard input stream
-// of the child process.
-fn run_quiet_stdin<W: FnOnce(&mut ChildStdin) -> Result<(), String>>(
+// Run a command, forward its standard error stream, and return its standard output. Accepts a
+// closure which receives a pipe to the standard input stream of the child process.
+fn run_quiet_stdin<W: FnOnce(&mut ChildStdin) -> Result<(), Failure>>(
     spinner_message: &str,
     error: &str,
     args: &[&str],
     writer: W,
     interrupted: &Arc<AtomicBool>,
-) -> Result<String, String> {
+) -> Result<String, Failure> {
+    // Render a spinner animation and clear it when we're done.
     let _guard = spin(spinner_message);
 
+    // This is used to determine whether the user interrupted the program during the execution of
+    // the child process.
+    let was_interrupted = interrupted.load(Ordering::SeqCst);
+
+    // Run the child process.
     let mut child = command(args)
         .stdin(Stdio::piped()) // [tag:run_quiet_stdin_piped]
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| {
-            format!(
-                "{} Perhaps you don't have Docker installed. Details: {}.",
-                error, e
-            )
-        })?;
-    writer(child.stdin.as_mut().unwrap())?; // [ref:run_quiet_stdin_piped]
-    let output = child.wait_with_output().map_err(|e| {
-        format!(
-            "{} Perhaps you don't have Docker installed. Details: {}.",
-            error, e
-        )
-    })?;
+        .map_err(system_error(&format!(
+            "{} Perhaps you don't have Docker installed.",
+            error
+        )))?;
 
+    // Pipe data to the child's standard input stream.
+    writer(child.stdin.as_mut().unwrap())?; // [ref:run_quiet_stdin_piped]
+
+    // Wait for the child to terminate.
+    let output = child.wait_with_output().map_err(system_error(&format!(
+        "{} Perhaps you don't have Docker installed.",
+        error
+    )))?;
+
+    // Handle the result.
     if output.status.success() {
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
     } else {
-        Err(if output.status.code().is_none() {
-            interrupted.store(true, Ordering::SeqCst);
-            super::INTERRUPT_MESSAGE.to_owned()
-        } else {
-            format!(
-                "{} Details:\n{}",
-                error,
-                String::from_utf8_lossy(&output.stderr)
-            )
-        })
+        Err(
+            if output.status.code().is_none()
+                || (!was_interrupted && interrupted.load(Ordering::SeqCst))
+            {
+                interrupted.store(true, Ordering::SeqCst);
+                Failure::Interrupted
+            } else {
+                Failure::System(
+                    format!(
+                        "{} Details:\n{}",
+                        error,
+                        String::from_utf8_lossy(&output.stderr)
+                    ),
+                    None,
+                )
+            },
+        )
     }
 }
 
-// Run a command and forward its standard output and error streams. Accepts a
-// closure which receives a pipe to the standard input stream of the child
-// process.
-fn run_loud_stdin<W: FnOnce(&mut ChildStdin) -> Result<(), String>>(
+// Run a command and forward its standard output and error streams. Accepts a closure which receives
+// a pipe to the standard input stream of the child process.
+fn run_loud_stdin<W: FnOnce(&mut ChildStdin) -> Result<(), Failure>>(
     error: &str,
     args: &[&str],
     writer: W,
     interrupted: &Arc<AtomicBool>,
-) -> Result<(), String> {
+) -> Result<(), Failure> {
+    // This is used to determine whether the user interrupted the program during the execution of
+    // the child process.
+    let was_interrupted = interrupted.load(Ordering::SeqCst);
+
+    // Run the child process.
     let mut child = command(args)
         .stdin(Stdio::piped()) // [tag:run_loud_stdin_piped]
         .spawn()
-        .map_err(|e| {
-            format!(
-                "{} Perhaps you don't have Docker installed. Details: {}.",
-                error, e
-            )
-        })?;
-    writer(child.stdin.as_mut().unwrap())?; // [ref:run_loud_stdin_piped]
-    let status = child.wait().map_err(|e| {
-        format!(
-            "{} Perhaps you don't have Docker installed. Details: {}.",
-            error, e
-        )
-    })?;
+        .map_err(system_error(&format!(
+            "{} Perhaps you don't have Docker installed.",
+            error
+        )))?;
 
+    // Pipe data to the child's standard input stream.
+    writer(child.stdin.as_mut().unwrap())?; // [ref:run_loud_stdin_piped]
+
+    // Wait for the child to terminate.
+    let status = child.wait().map_err(system_error(&format!(
+        "{} Perhaps you don't have Docker installed.",
+        error
+    )))?;
+
+    // Handle the result.
     if status.success() {
         Ok(())
     } else {
-        Err(if status.code().is_none() {
-            interrupted.store(true, Ordering::SeqCst);
-            super::INTERRUPT_MESSAGE
-        } else {
-            error
-        }
-        .to_owned())
+        Err(
+            if status.code().is_none() || (!was_interrupted && interrupted.load(Ordering::SeqCst)) {
+                interrupted.store(true, Ordering::SeqCst);
+                Failure::Interrupted
+            } else {
+                Failure::System(error.to_owned(), None)
+            },
+        )
     }
 }
 
 // Run a command and forward its standard input, output, and error streams.
-fn run_attach(
-    error: &str,
-    args: &[&str],
-    interrupted: &Arc<AtomicBool>,
-) -> Result<(), String> {
-    let status = command(args).status().map_err(|e| {
-        format!(
-            "{} Perhaps you don't have Docker installed. Details: {}.",
-            error, e
-        )
-    })?;
+fn run_attach(error: &str, args: &[&str], interrupted: &Arc<AtomicBool>) -> Result<(), Failure> {
+    // This is used to determine whether the user interrupted the program during the execution of
+    // the child process.
+    let was_interrupted = interrupted.load(Ordering::SeqCst);
 
+    // Run the child process.
+    let status = command(args).status().map_err(system_error(&format!(
+        "{} Perhaps you don't have Docker installed.",
+        error
+    )))?;
+
+    // Handle the result.
     if status.success() {
         Ok(())
     } else {
-        Err(if status.code().is_none() {
-            interrupted.store(true, Ordering::SeqCst);
-            super::INTERRUPT_MESSAGE
-        } else {
-            error
-        }
-        .to_owned())
+        Err(
+            if status.code().is_none() || (!was_interrupted && interrupted.load(Ordering::SeqCst)) {
+                interrupted.store(true, Ordering::SeqCst);
+                Failure::Interrupted
+            } else {
+                Failure::System(error.to_owned(), None)
+            },
+        )
     }
 }
 

--- a/src/failure.rs
+++ b/src/failure.rs
@@ -1,0 +1,48 @@
+use std::{error, fmt};
+
+// We distinguish between three kinds of failures:
+// 1. The user interrupted the program
+// 2. Some system operation (e.g., creating a container) failed
+// 3. There was a problem with the user's input (e.g., their task failed)
+#[derive(Debug)]
+pub enum Failure {
+    Interrupted, // E.g., by SIGINT or SIGTERM
+    System(String, Option<Box<dyn error::Error + 'static>>),
+    User(String, Option<Box<dyn error::Error + 'static>>),
+}
+
+impl fmt::Display for Failure {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Failure::System(message, None) | Failure::User(message, None) => {
+                write!(f, "{}", message)
+            }
+            Failure::System(message, Some(source)) | Failure::User(message, Some(source)) => {
+                write!(f, "{} Reason: {}", message, source)
+            }
+            Failure::Interrupted => write!(f, "Interrupted."),
+        }
+    }
+}
+
+impl error::Error for Failure {
+    fn source<'a>(&'a self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Failure::System(_, source) => source.as_ref().map(|e| &**e),
+            Failure::User(_, source) => source.as_ref().map(|e| &**e),
+            Failure::Interrupted => None,
+        }
+    }
+}
+
+// A helper function to convert a `std::error::Error` into a system failure
+pub fn system_error<E: error::Error + 'static>(message: &str) -> impl FnOnce(E) -> Failure {
+    let message = message.to_owned();
+    move |error: E| Failure::System(message, Some(Box::new(error)))
+}
+
+// A helper function to convert a `std::error::Error` into a user failure
+pub fn user_error<E: error::Error + 'static>(message: &str) -> impl FnOnce(E) -> Failure {
+    let message = message.to_owned();
+    move |error: E| Failure::User(message, Some(Box::new(error)))
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,8 +1,7 @@
 use atty::Stream;
 use colored::{ColoredString, Colorize};
 
-// This trait has a function for formatting "code-like" text, such as a task
-// name or a file path.
+// This trait has a function for formatting "code-like" text, such as a task name or a file path.
 pub trait CodeStr {
     fn code_str(&self) -> ColoredString;
 }
@@ -17,9 +16,8 @@ impl CodeStr for str {
     }
 }
 
-// This function takes a number and a noun and returns a string representing
-// the noun with the given multiplicity (pluralizing if necessary). For
-// example, (3, "cow") becomes "3 cows".
+// This function takes a number and a noun and returns a string representing the noun with the
+// given multiplicity (pluralizing if necessary). For example, (3, "cow") becomes "3 cows".
 pub fn number(n: usize, noun: &str) -> String {
     if n == 1 {
         format!("{} {}", n, noun)
@@ -28,9 +26,8 @@ pub fn number(n: usize, noun: &str) -> String {
     }
 }
 
-// This function takes an array of strings and returns a comma-separated list
-// with the word "and" (and an Oxford comma, if applicable) between the last
-// two items.
+// This function takes an array of strings and returns a comma-separated list with the word "and"
+// (and an Oxford comma, if applicable) between the last two items.
 pub fn series(items: &[String]) -> String {
     match items.len() {
         0 => "".to_owned(),
@@ -75,10 +72,7 @@ mod tests {
 
     #[test]
     fn series_two() {
-        assert_eq!(
-            series(&["foo".to_owned(), "bar".to_owned()]),
-            "foo and bar"
-        );
+        assert_eq!(series(&["foo".to_owned(), "bar".to_owned()]), "foo and bar");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cache;
 mod config;
 mod docker;
+mod failure;
 mod format;
 mod runner;
 mod schedule;
@@ -8,7 +9,10 @@ mod spinner;
 mod tar;
 mod toastfile;
 
-use crate::format::CodeStr;
+use crate::{
+    failure::{system_error, user_error, Failure},
+    format::CodeStr,
+};
 use atty::Stream;
 use clap::{App, AppSettings, Arg};
 use env_logger::{fmt::Color, Builder};
@@ -58,17 +62,13 @@ const REPO_ARG: &str = "repo";
 const SHELL_ARG: &str = "shell";
 const TASKS_ARG: &str = "tasks";
 
-// The error message to log when Toast is interrupted.
-const INTERRUPT_MESSAGE: &str = "Interrupted.";
-
 // Set up the logger.
 fn set_up_logging() {
     Builder::new()
         .filter_module(
             module_path!(),
             LevelFilter::from_str(
-                &env::var("LOG_LEVEL")
-                    .unwrap_or_else(|_| DEFAULT_LOG_LEVEL.to_string()),
+                &env::var("LOG_LEVEL").unwrap_or_else(|_| DEFAULT_LOG_LEVEL.to_string()),
             )
             .unwrap_or_else(|_| DEFAULT_LOG_LEVEL),
         )
@@ -104,41 +104,40 @@ fn set_up_logging() {
 fn set_up_signal_handlers(
     interrupted: Arc<AtomicBool>,
     active_containers: Arc<Mutex<HashSet<String>>>,
-) -> Result<(), String> {
-    // If Toast is in the foreground process group for some TTY, the process will
-    // receive a SIGINT when the user types CTRL+C at the terminal. The default
-    // behavior is to crash when this signal is received. However, we would
-    // rather clean up resources before terminating, so we trap the signal here.
-    // This code also traps SIGTERM, because we compile the `ctrlc` crate with
-    // the `termination` feature [ref:ctrlc_term].
+) -> Result<(), Failure> {
+    // If Toast is in the foreground process group for some TTY, the process will receive a SIGINT
+    // when the user types CTRL+C at the terminal. The default behavior is to crash when this signal
+    // is received. However, we would rather clean up resources before terminating, so we trap the
+    // signal here. This code also traps SIGTERM, because we compile the `ctrlc` crate with the
+    // `termination` feature [ref:ctrlc_term].
     ctrlc::set_handler(move || {
         // Let the rest of the program know the user wants to quit.
         if interrupted.swap(true, Ordering::SeqCst) {
-            // Stop any active containers. The `unwrap` will only fail if a panic
-            // already occurred.
+            // Stop any active containers. The `unwrap` will only fail if a panic already occurred.
             for container in &*active_containers.lock().unwrap() {
-                if let Err(e) =
-                    docker::stop_container(&container, &interrupted)
-                {
+                if let Err(e) = docker::stop_container(&container, &interrupted) {
                     error!("{}", e);
                 }
             }
 
-            // We may have been in the middle of printing a line of output. Here we
-            // print a newline to prepare for further printing.
+            // We may have been in the middle of printing a line of output. Here we print a newline
+            // to prepare for further printing.
             let _ = stdout().write(b"\n");
         }
     })
-    .map_err(|e| format!("Error installing signal handler. Details: {}.", e))
+    .map_err(system_error("Error installing signal handler."))
 }
 
 // Convert a string (from a command-line argument) into a Boolean.
-fn parse_bool(s: &str) -> Result<bool, String> {
+fn parse_bool(s: &str) -> Result<bool, Failure> {
     let normalized = s.trim().to_lowercase();
     match normalized.as_ref() {
         "true" | "yes" => Ok(true),
         "false" | "no" => Ok(false),
-        _ => Err(format!("{} is not a Boolean.", s.code_str())),
+        _ => Err(Failure::User(
+            format!("{} is not a Boolean.", s.code_str()),
+            None,
+        )),
     }
 }
 
@@ -155,7 +154,7 @@ pub struct Settings {
 }
 
 // Parse the command-line arguments;
-fn settings() -> Result<Settings, String> {
+fn settings() -> Result<Settings, Failure> {
     let matches = App::new("Toast")
         .version(VERSION)
         .version_short("v")
@@ -233,24 +232,22 @@ fn settings() -> Result<Settings, String> {
     // Find the toastfile.
     let toastfile_path = matches.value_of(TOASTFILE_ARG).map_or_else(
         || {
-            let mut candidate_dir = current_dir().map_err(|e| {
-                format!(
-                    "Unable to determine working directory. Details: {}.",
-                    e
-                )
-            })?;
+            let mut candidate_dir =
+                current_dir().map_err(system_error("Unable to determine working directory."))?;
             loop {
-                let candidate_path =
-                    candidate_dir.join(TOASTFILE_DEFAULT_NAME);
+                let candidate_path = candidate_dir.join(TOASTFILE_DEFAULT_NAME);
                 if let Ok(metadata) = fs::metadata(&candidate_path) {
                     if metadata.file_type().is_file() {
                         return Ok(candidate_path);
                     }
                 }
                 if !candidate_dir.pop() {
-                    return Err(format!(
-                        "Unable to locate file {}.",
-                        TOASTFILE_DEFAULT_NAME.code_str()
+                    return Err(Failure::User(
+                        format!(
+                            "Unable to locate file {}.",
+                            TOASTFILE_DEFAULT_NAME.code_str()
+                        ),
+                        None,
                     ));
                 }
             }
@@ -259,8 +256,7 @@ fn settings() -> Result<Settings, String> {
     )?;
 
     // Read the config file path.
-    let default_config_file_path =
-        dirs::config_dir().map(|path| path.join(CONFIG_FILE_XDG_PATH));
+    let default_config_file_path = dirs::config_dir().map(|path| path.join(CONFIG_FILE_XDG_PATH));
     let config_file_path = matches.value_of(CONFIG_FILE_ARG).map_or_else(
         || default_config_file_path,
         |path| Some(PathBuf::from(path)),
@@ -278,9 +274,7 @@ fn settings() -> Result<Settings, String> {
         })
         .map_or_else(
             || {
-                debug!(
-          "Configuration file not found. Using the default configuration."
-        );
+                debug!("Configuration file not found. Using the default configuration.");
                 config::EMPTY_CONFIG.to_owned()
             },
             |data| {
@@ -288,17 +282,14 @@ fn settings() -> Result<Settings, String> {
                 data
             },
         );
-    let config = config::parse(&config_data).map_err(|e| {
-        format!(
-            "Unable to parse file {}. Details: {}",
-            config_file_path
-                .as_ref()
-                .unwrap()
-                .to_string_lossy()
-                .code_str(), // Manually verified safe
-            e
-        )
-    })?;
+    let config = config::parse(&config_data).map_err(user_error(&format!(
+        "Unable to parse file {}.",
+        config_file_path
+            .as_ref()
+            .unwrap()
+            .to_string_lossy()
+            .code_str(), // Manually verified safe
+    )))?;
 
     // Read the local caching switches.
     let read_local_cache = matches
@@ -345,33 +336,25 @@ fn settings() -> Result<Settings, String> {
 }
 
 // Parse a toastfile.
-fn parse_toastfile(
-    toastfile_path: &Path,
-) -> Result<toastfile::Toastfile, String> {
+fn parse_toastfile(toastfile_path: &Path) -> Result<toastfile::Toastfile, Failure> {
     // Read the file from disk.
-    let toastfile_data = fs::read_to_string(toastfile_path).map_err(|e| {
-        format!(
-            "Unable to read file {}. Details: {}.",
-            toastfile_path.to_string_lossy().code_str(),
-            e
-        )
-    })?;
+    let toastfile_data = fs::read_to_string(toastfile_path).map_err(user_error(&format!(
+        "Unable to read file {}.",
+        toastfile_path.to_string_lossy().code_str(),
+    )))?;
 
     // Parse it.
-    toastfile::parse(&toastfile_data).map_err(|e| {
-        format!(
-            "Unable to parse file {}. Details: {}",
-            toastfile_path.to_string_lossy().code_str(),
-            e
-        )
-    })
+    toastfile::parse(&toastfile_data).map_err(user_error(&format!(
+        "Unable to parse file {}.",
+        toastfile_path.to_string_lossy().code_str()
+    )))
 }
 
 // Determine which tasks the user wants to run.
 fn get_roots<'a>(
     settings: &'a Settings,
     toastfile: &'a toastfile::Toastfile,
-) -> Result<Vec<&'a str>, String> {
+) -> Result<Vec<&'a str>, Failure> {
     settings.tasks.as_ref().map_or_else(
         || {
             // The user didn't provide any tasks. Check if there is a default task.
@@ -392,10 +375,13 @@ fn get_roots<'a>(
             for task in tasks {
                 if !toastfile.tasks.contains_key(task) {
                     // [tag:tasks_valid]
-                    return Err(format!(
-                        "No task named {} in {}.",
-                        task.code_str(),
-                        settings.toastfile_path.to_string_lossy().code_str()
+                    return Err(Failure::User(
+                        format!(
+                            "No task named {} in {}.",
+                            task.code_str(),
+                            settings.toastfile_path.to_string_lossy().code_str()
+                        ),
+                        None,
                     ));
                 }
             }
@@ -409,7 +395,7 @@ fn get_roots<'a>(
 fn fetch_environment(
     schedule: &[&str],
     tasks: &HashMap<String, toastfile::Task>,
-) -> Result<HashMap<String, String>, String> {
+) -> Result<HashMap<String, String>, Failure> {
     let mut env = HashMap::new();
     let mut violations = HashMap::new();
 
@@ -427,24 +413,28 @@ fn fetch_environment(
 
     if !violations.is_empty() {
         // [tag:environment_valid]
-        return Err(format!(
-      "The following tasks use variables which are missing from the environment: {}.",
-      format::series(
-        violations
-          .iter()
-          .map(|(task, vars)| format!(
-            "{} ({})",
-            task.code_str(),
-            format::series(
-              vars
-                .iter()
-                .map(|var| format!("{}", var.code_str()))
-                .collect::<Vec<_>>().as_ref()
-            )
-          ))
-          .collect::<Vec<_>>().as_ref()
-      )
-    ));
+        return Err(Failure::User(
+            format!(
+                "The following tasks use variables which are missing from the environment: {}.",
+                format::series(
+                    violations
+                        .iter()
+                        .map(|(task, vars)| format!(
+                            "{} ({})",
+                            task.code_str(),
+                            format::series(
+                                vars.iter()
+                                    .map(|var| format!("{}", var.code_str()))
+                                    .collect::<Vec<_>>()
+                                    .as_ref()
+                            )
+                        ))
+                        .collect::<Vec<_>>()
+                        .as_ref()
+                )
+            ),
+            None,
+        ));
     }
 
     Ok(env)
@@ -459,14 +449,13 @@ fn run_tasks(
     environment: &HashMap<String, String>,
     interrupted: &Arc<AtomicBool>,
     active_containers: &Arc<Mutex<HashSet<String>>>,
-) -> Result<runner::Context, (String, runner::Context)> {
-    // This variable will be `true` as long as we're executing tasks that have
-    // `cache: true`. As soon as we encounter a task with `cache: false`, this
-    // variable will be permanently set to `false`.
+) -> (Result<(), Failure>, runner::Context) {
+    // This variable will be `true` as long as we're executing tasks that have `cache: true`. As
+    // soon as we encounter a task with `cache: false`, this variable will be permanently set to
+    // `false`.
     let mut caching_enabled = true;
 
-    // This is the cache key for the current task. We initialize it with the base
-    // image name.
+    // This is the cache key for the current task. We initialize it with the base image name.
     let mut cache_key = toastfile.image.clone();
 
     // We start with the base image.
@@ -481,18 +470,18 @@ fn run_tasks(
         // Fetch the data for the current task.
         let task_data = &toastfile.tasks[*task]; // [ref:tasks_valid]
 
-        // If the current task is not cacheable, don't read or write to any form of
-        // cache from now on.
+        // If the current task is not cacheable, don't read or write to any form of cache from now
+        // on.
         caching_enabled = caching_enabled && task_data.cache;
 
         // If the user wants to stop the schedule, quit now.
         if interrupted.load(Ordering::SeqCst) {
-            return Err((INTERRUPT_MESSAGE.to_owned(), context));
+            return (Err(Failure::Interrupted), context);
         }
 
         // Run the task.
         info!("Running task {}\u{2026}", task.code_str());
-        let (new_cache_key, new_context) = runner::run(
+        let (result, new_context) = runner::run(
             settings,
             &environment,
             &interrupted,
@@ -501,19 +490,24 @@ fn run_tasks(
             &cache_key,
             caching_enabled,
             context,
-        )?;
+        );
 
-        // Remember the cache key and context for the next task.
-        cache_key = new_cache_key;
+        // Remember the context for the next task.
         context = new_context;
+
+        // Retrieve the cache key from the result.
+        cache_key = match result {
+            Ok(new_cache_key) => new_cache_key,
+            Err(e) => return (Err(e), context),
+        };
     }
 
     // Everything succeeded.
-    Ok(context)
+    (Ok(()), context)
 }
 
 // Program entrypoint
-fn entry() -> Result<(), String> {
+fn entry() -> Result<(), Failure> {
     // Determine whether to print colored output.
     colored::control::set_override(atty::is(Stream::Stdout));
 
@@ -556,35 +550,33 @@ fn entry() -> Result<(), String> {
     let environment = fetch_environment(&schedule, &toastfile.tasks)?;
 
     // Execute the schedule.
-    let (succeeded, context) = match run_tasks(
+    let (result, context) = run_tasks(
         &schedule,
         &settings,
         &toastfile,
         &environment,
         &interrupted,
         &active_containers,
-    ) {
-        Ok(context) => {
-            // Log the success and proceed in case the user wants to be dropped into
-            // a shell.
-            info!("Done.");
-            (true, context)
-        }
-        Err((e, context)) => {
-            // If the schedule failed because the user interrupted a task, quit now.
-            if interrupted.load(Ordering::SeqCst) {
-                return Err(INTERRUPT_MESSAGE.to_owned());
-            }
+    );
 
-            // Log the error and proceed in case the user wants to be dropped into a
-            // shell.
-            error!("{}", e);
-            (false, context)
+    // Return early if needed.
+    match result {
+        Ok(_) | Err(Failure::User(_, _)) => {
+            // Proceed in case the user wants to drop into a shell.
+        }
+        Err(Failure::Interrupted) | Err(Failure::System(_, _)) => {
+            // There was an error not caused by a regular task failure. Quit now.
+            return result;
         }
     };
 
     // Drop the user into a shell if requested.
     if settings.spawn_shell {
+        // If one of the tasks failed, tell the user now before we drop into a shell.
+        if let Err(e) = &result {
+            error!("{}", e);
+        }
+
         // Inform the user of what's about to happen.
         info!("Preparing a shell\u{2026}");
 
@@ -592,12 +584,8 @@ fn entry() -> Result<(), String> {
         docker::spawn_shell(&context.image, &interrupted)?;
     }
 
-    // Throw an error if any of the tasks failed.
-    if succeeded {
-        Ok(())
-    } else {
-        Err("One of the tasks failed.".to_owned())
-    }
+    // Return the result to the user.
+    result
 }
 
 // Let the fun begin!

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,29 +1,24 @@
 use crate::toastfile::Toastfile;
 use std::{collections::HashSet, convert::AsRef};
 
-// Compute a topological sort of the transitive reflexive closure of a set of
-// tasks. The resulting schedule does not depend on the order of the inputs or
-// dependencies. We assume the tasks form a DAG [ref:tasks_dag].
-pub fn compute<'a>(
-    toastfile: &'a Toastfile,
-    tasks: &[&'a str],
-) -> Vec<&'a str> {
+// Compute a topological sort of the transitive reflexive closure of a set of tasks. The resulting
+// schedule does not depend on the order of the inputs or dependencies. We assume the tasks form a
+// DAG [ref:tasks_dag].
+pub fn compute<'a>(toastfile: &'a Toastfile, tasks: &[&'a str]) -> Vec<&'a str> {
     // Sort the input tasks to ensure the given order doesn't matter.
     let mut roots: Vec<&'a str> = tasks.to_vec();
     roots.sort();
 
-    // We will use this set to keep track of what tasks have already been
-    // seen.
+    // We will use this set to keep track of what tasks have already been seen.
     let mut visited: HashSet<&'a str> = HashSet::new();
 
     // This vector accumulates the final schedule.
     let mut schedule: Vec<&'a str> = vec![];
 
-    // For each root, compute its transitive reflexive closure, topsort it, and
-    // add it to the schedule.
+    // For each root, compute its transitive reflexive closure, topsort it, and add it to the
+    // schedule.
     for root in roots {
-        // The frontier is a stack, which means we are doing a depth-first
-        // traversal.
+        // The frontier is a stack, which means we are doing a depth-first traversal.
         let mut frontier: Vec<(&'a str, bool)> = vec![(root, true)];
 
         // This vector will accumulate the topsorted tasks.
@@ -35,8 +30,8 @@ pub fn compute<'a>(
             // Pop a task from the frontier. [ref:schedule_frontier_nonempty]
             let (task, new) = frontier.pop().unwrap();
 
-            // Check if this is a new task or one that we are coming back to because
-            // we finished processing its dependencies.
+            // Check if this is a new task or one that we are coming back to because we finished
+            // processing its dependencies.
             if new {
                 // If we have already scheduled this root task, skip to the next one.
                 if visited.contains(task) {
@@ -49,11 +44,10 @@ pub fn compute<'a>(
                 // Come back to this task once all its dependencies have been processed.
                 frontier.push((task, false));
 
-                // Add the task's dependencies to the frontier. We sort the
-                // dependencies first to ensure their original order doesn't matter.
-                // After sorting, we reverse the order of the dependencies before
-                // adding them to the frontier so that they will be processed in
-                // lexicographical order (since the frontier is a stack rather than a
+                // Add the task's dependencies to the frontier. We sort the dependencies first to
+                // ensure their original order doesn't matter. After sorting, we reverse the order
+                // of the dependencies before adding them to the frontier so that they will be
+                // processed in lexicographical order (since the frontier is a stack rather than a
                 // queue). The indexing is safe due to [ref:tasks_valid].
                 let mut dependencies: Vec<&'a str> = toastfile.tasks[task]
                     .dependencies
@@ -217,11 +211,7 @@ mod tests {
         tasks1.insert("bar".to_owned(), empty_task());
         tasks1.insert(
             "baz".to_owned(),
-            task_with_dependencies(vec![
-                "foo".to_owned(),
-                "bar".to_owned(),
-                "foo".to_owned(),
-            ]),
+            task_with_dependencies(vec!["foo".to_owned(), "bar".to_owned(), "foo".to_owned()]),
         );
 
         let mut tasks2 = HashMap::new();
@@ -229,11 +219,7 @@ mod tests {
         tasks2.insert("bar".to_owned(), empty_task());
         tasks2.insert(
             "baz".to_owned(),
-            task_with_dependencies(vec![
-                "bar".to_owned(),
-                "foo".to_owned(),
-                "bar".to_owned(),
-            ]),
+            task_with_dependencies(vec!["bar".to_owned(), "foo".to_owned(), "bar".to_owned()]),
         );
 
         let toastfile1 = Toastfile {
@@ -281,11 +267,7 @@ mod tests {
         tasks1.insert("baz".to_owned(), empty_task());
         tasks1.insert(
             "qux".to_owned(),
-            task_with_dependencies(vec![
-                "foo".to_owned(),
-                "bar".to_owned(),
-                "baz".to_owned(),
-            ]),
+            task_with_dependencies(vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]),
         );
 
         let mut tasks2 = HashMap::new();
@@ -294,11 +276,7 @@ mod tests {
         tasks2.insert("baz".to_owned(), empty_task());
         tasks2.insert(
             "qux".to_owned(),
-            task_with_dependencies(vec![
-                "baz".to_owned(),
-                "bar".to_owned(),
-                "foo".to_owned(),
-            ]),
+            task_with_dependencies(vec!["baz".to_owned(), "bar".to_owned(), "foo".to_owned()]),
         );
 
         let toastfile1 = Toastfile {

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -11,11 +11,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-// Render a spinner in the terminal. When the returned value is dropped, the
-// spinner is stopped.
+// Render a spinner in the terminal. When the returned value is dropped, the spinner is stopped.
 pub fn spin(message: &str) -> impl Drop {
-    // Start a thread for our spinner-as-a-service. This thread will only be
-    // created once and will live for the duration of the whole program.
+    // Start a thread for our spinner-as-a-service. This thread will only be created once and will
+    // live for the duration of the whole program.
     lazy_static! {
       static ref SPINNER_SERVICE: Sender<(String, Arc<AtomicBool>, Sender<()>)> = {
         // Create a channel for requests to start spinning.
@@ -24,8 +23,7 @@ pub fn spin(message: &str) -> impl Drop {
 
         // Start a thread to handle spinner requests.
         thread::spawn(move || loop {
-          // Wait for a request. The `unwrap` is safe since we never hang up the
-          // channel.
+          // Wait for a request. The `unwrap` is safe since we never hang up the channel.
           let (message, spinning, response_sender) =
             request_receiver.recv().unwrap();
 
@@ -40,10 +38,9 @@ pub fn spin(message: &str) -> impl Drop {
             // Render the next frame of the spinner.
             spinner.tick();
 
-            // For the first 100ms, we animate on a shorter time interval so we
-            // can stop faster if the work finishes instantly. If the work takes
-            // longer than that, we slow the animation down out of courtesy for
-            // the CPU.
+            // For the first 100ms, we animate on a shorter time interval so we can stop faster if
+            // the work finishes instantly. If the work takes longer than that, we slow the
+            // animation down out of courtesy for the CPU.
             if now.elapsed() < Duration::from_millis(100) {
               sleep(Duration::from_millis(16));
             } else {
@@ -54,13 +51,12 @@ pub fn spin(message: &str) -> impl Drop {
           // Clean up the spinner.
           spinner.finish_and_clear();
 
-          // Inform the caller that the spinner has been cleaned up. The `unwrap`
-          // is safe since we never hang up the channel.
+          // Inform the caller that the spinner has been cleaned up. The `unwrap` is safe since we
+          // never hang up the channel.
           response_sender.send(()).unwrap();
         });
 
-        // The sender half of the request channel is the API for this spinner
-        // service. Return it.
+        // The sender half of the request channel is the API for this spinner service. Return it.
         request_sender
       };
     }
@@ -71,8 +67,7 @@ pub fn spin(message: &str) -> impl Drop {
     // This will be set to `false` when it's time to stop the spinner.
     let spinning = Arc::new(AtomicBool::new(true));
 
-    // Create and animate the spinner. The `unwrap` is safe since we never hang
-    // up the channel.
+    // Create and animate the spinner. The `unwrap` is safe since we never hang up the channel.
     SPINNER_SERVICE
         .send((message.to_owned(), spinning.clone(), response_sender))
         .unwrap();
@@ -82,8 +77,7 @@ pub fn spin(message: &str) -> impl Drop {
         // Tell the spinner service to stop the spinner.
         spinning.store(false, Ordering::SeqCst);
 
-        // Wait for the spinner to stop. The `unwrap` is safe since we never hang
-        // up the channel.
+        // Wait for the spinner to stop. The `unwrap` is safe since we never hang up the channel.
         response_receiver.recv().unwrap();
     })
 }

--- a/src/tar.rs
+++ b/src/tar.rs
@@ -1,4 +1,9 @@
-use crate::{cache, format::CodeStr, spinner::spin};
+use crate::{
+    cache,
+    failure::{system_error, user_error, Failure},
+    format::CodeStr,
+    spinner::spin,
+};
 use std::{
     fs::File,
     io::{empty, Read, Seek, SeekFrom, Write},
@@ -20,20 +25,20 @@ pub fn append<R: Read, W: Write>(
     size: u64,
     entry_type: EntryType,
     executable: bool,
-) {
-    // Tar archives must contain only relative paths. But for our purposes, the
-    // paths will be relative to the filesystem root, so we can just strip the
-    // leading `/`. The `unwrap` is safe due to the prefix check.
+) -> Result<(), Failure> {
+    // Tar archives must contain only relative paths. But for our purposes, the paths will be
+    // relative to the filesystem root, so we can just strip the leading `/`. The `unwrap` is safe
+    // due to the prefix check.
     let destination = if path.starts_with("/") {
         path.strip_prefix("/").unwrap().to_owned()
     } else {
         path.to_owned()
     };
 
-    // If destination is the root path `/`, there is nothing to do. That path
-    // already exists in any file system.
+    // If destination is the root path `/`, there is nothing to do. That path already exists in any
+    // file system.
     if destination.parent().is_none() {
-        return;
+        return Ok(());
     }
 
     // Construct a tar header for this entry.
@@ -43,7 +48,12 @@ pub fn append<R: Read, W: Write>(
 
     // Add the entry to the archive.
     header.set_entry_type(entry_type);
-    builder.append_data(&mut header, destination, data).unwrap();
+    builder
+        .append_data(&mut header, destination, data)
+        .map_err(system_error("Error appending data to tar archive."))?;
+
+    // Everything succeeded.
+    Ok(())
 }
 
 // Construct a tar archive and return a hash of its contents.
@@ -54,23 +64,19 @@ pub fn create<W: Write>(
     source_dir: &Path,
     destination_dir: &Path,
     interrupted: &Arc<AtomicBool>,
-) -> Result<(W, String), String> {
+) -> Result<(W, String), Failure> {
     // Render a spinner animation in the terminal.
     let _guard = spin(spinner_message);
 
-    // Canonicalize the source directory such that other paths can be relativized
-    // with respect to it.
-    let source_dir = source_dir.canonicalize().map_err(|e| {
-        format!(
-            "Unable to canonicalize path {}. Details: {}.",
-            source_dir.to_string_lossy().code_str(),
-            e
-        )
-    })?;
+    // Canonicalize the source directory such that other paths can be relativized with respect to
+    // it.
+    let source_dir = source_dir.canonicalize().map_err(system_error(&format!(
+        "Unable to canonicalize path {}.",
+        source_dir.to_string_lossy().code_str(),
+    )))?;
 
-    // This vector will store all the hashes of the contents and metadata of all
-    // the files in the archive. In the end, we will sort this vector and then
-    // take the hash of the whole thing.
+    // This vector will store all the hashes of the contents and metadata of all the files in the
+    // archive. In the end, we will sort this vector and then take the hash of the whole thing.
     let mut file_hashes = vec![];
 
     // This builder will be responsible for writing to the tar file.
@@ -85,78 +91,60 @@ pub fn create<W: Write>(
         0,
         EntryType::Directory,
         true,
-    );
+    )?;
 
     // Add each path to the archive.
     for relative_input_path in input_paths {
-        // Compute the source path.
+        // Compute the absolute input path.
         let absolute_input_path = source_dir.join(relative_input_path);
 
-        // The path is a directory, so we need to traverse it.
+        // Traverse the absolute input path.
         for entry in WalkDir::new(&absolute_input_path) {
             // If the user wants to stop the operation, quit now.
             if interrupted.load(Ordering::SeqCst) {
-                return Err(super::INTERRUPT_MESSAGE.to_owned());
+                return Err(Failure::Interrupted);
             }
 
             // Unwrap the entry.
-            let entry = entry.map_err(|e| {
-                format!(
-                    "Unable to traverse path {}. Details: {}.",
-                    &absolute_input_path.to_string_lossy().code_str(),
-                    e
-                )
-            })?;
+            let entry = entry.map_err(user_error(&format!(
+                "Unable to traverse path {}.",
+                &absolute_input_path.to_string_lossy().code_str(),
+            )))?;
 
             // Fetch the metadata for this entry.
-            let entry_metadata = entry.metadata().map_err(|e| {
-                format!(
-                    "Unable to fetch filesystem metadata for {}. Details: {}.",
-                    &absolute_input_path.to_string_lossy().code_str(),
-                    e
-                )
-            })?;
+            let entry_metadata = entry.metadata().map_err(system_error(&format!(
+                "Unable to fetch filesystem metadata for {}.",
+                &absolute_input_path.to_string_lossy().code_str(),
+            )))?;
 
             // Fetch the host path.
             let absolute_host_path =
-                entry.path().canonicalize().map_err(|e| {
-                    format!(
-                        "Unable to canonicalize path {}. Details: {}.",
-                        &entry.path().to_string_lossy().code_str(),
-                        e
-                    )
-                })?;
+                entry.path().canonicalize().map_err(system_error(&format!(
+                    "Unable to canonicalize path {}.",
+                    &entry.path().to_string_lossy().code_str(),
+                )))?;
 
             // Relativize the host path.
             let relative_path = absolute_host_path
                 .strip_prefix(&source_dir)
-                .map_err(|e| {
-                    format!(
-            "Unable to relativize path {} with respect to {}. Details: {}.",
-            &entry.path().to_string_lossy().code_str(),
-            &source_dir.to_string_lossy().code_str(),
-            e
-          )
-                })?
+                .map_err(system_error(&format!(
+                    "Unable to relativize path {} with respect to {}.",
+                    &entry.path().to_string_lossy().code_str(),
+                    &source_dir.to_string_lossy().code_str(),
+                )))?
                 .to_owned();
 
-            // Check the type of the entry. Note that Toast ignores symbolic links.
-            // [ref:symlinks]
+            // Check the type of the entry. Note that Toast ignores symbolic links. [ref:symlinks]
             if entry.file_type().is_file() {
                 // Determine if the file has the executable bit set.
                 let mode = entry_metadata.permissions().mode();
-                let executable =
-                    mode & 0o1 > 0 || mode & 0o10 > 0 || mode & 0o100 > 0;
+                let executable = mode & 0o1 > 0 || mode & 0o10 > 0 || mode & 0o100 > 0;
 
                 // It's a file. Open it so we can compute the hash of its contents.
-                let mut file =
-                    File::open(&absolute_host_path).map_err(|e| {
-                        format!(
-                            "Unable to open file {}. Details: {}.",
-                            &absolute_host_path.to_string_lossy().code_str(),
-                            e
-                        )
-                    })?;
+                let mut file = File::open(&absolute_host_path).map_err(system_error(&format!(
+                    "Unable to open file {}.",
+                    &absolute_host_path.to_string_lossy().code_str(),
+                )))?;
 
                 // Compute the hash of the file contents and metadata.
                 file_hashes.push(cache::extend(
@@ -168,13 +156,11 @@ pub fn create<W: Write>(
                 ));
 
                 // Jump back to the beginning of the file so the tar builder can read it.
-                file.seek(SeekFrom::Start(0)).map_err(|e| {
-                    format!(
-                        "Unable to seek file {}. Details: {}.",
+                file.seek(SeekFrom::Start(0))
+                    .map_err(system_error(&format!(
+                        "Unable to seek file {}.",
                         &absolute_host_path.to_string_lossy().code_str(),
-                        e
-                    )
-                })?;
+                    )))?;
 
                 // Add the file to the archive and return.
                 append(
@@ -184,11 +170,10 @@ pub fn create<W: Write>(
                     entry_metadata.len(),
                     EntryType::Regular,
                     executable,
-                );
+                )?;
             } else if entry.file_type().is_dir() {
                 // It's a directory. Only its name is relevant for the cache key.
-                file_hashes
-                    .push(cache::hash_str(&relative_path.to_string_lossy()));
+                file_hashes.push(cache::hash_str(&relative_path.to_string_lossy()));
 
                 // Add the directory to the archive.
                 append(
@@ -198,20 +183,19 @@ pub fn create<W: Write>(
                     0,
                     EntryType::Directory,
                     true,
-                );
+                )?;
             }
         }
     }
 
-    // Sort the file hashes to ensure the directory traversal order doesn't
-    // matter.
+    // Sort the file hashes to ensure the directory traversal order doesn't matter.
     file_hashes.sort();
 
     // Return the tar file and the hash of its contents.
     Ok((
-        builder.into_inner().map_err(|e| {
-            format!("Error writing tar archive. Details: {}.", e)
-        })?,
+        builder
+            .into_inner()
+            .map_err(system_error("Error writing tar archive."))?,
         file_hashes
             .iter()
             .fold(cache::hash_str(""), |acc, x| cache::extend(&acc, x)),

--- a/toast.yml
+++ b/toast.yml
@@ -12,7 +12,8 @@ tasks:
       - install_packages
     command: |
       set -euo pipefail
-      curl https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh -LSfs | VERSION=1.2.0 sh
+      curl https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh -LSfs |
+        VERSION=1.2.0 sh
 
   create_user:
     command: |
@@ -26,7 +27,8 @@ tasks:
     user: user
     command: |
       set -euo pipefail
-      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable-2019-04-25-x86_64-unknown-linux-gnu
+      curl https://sh.rustup.rs -sSf |
+        sh -s -- -y --default-toolchain stable-2019-04-25-x86_64-unknown-linux-gnu
       . $HOME/.cargo/env
       rustup component add clippy
       rustup component add rustfmt
@@ -87,12 +89,12 @@ tasks:
       - install.sh # Linted by ShellCheck
       - integration-tests # Linted by ShellCheck
       - integration-tests.sh # Linted by ShellCheck
-      - rustfmt.toml # Used by `cargo fmt`
     user: user
     command: |
       set -euo pipefail
       . $HOME/.cargo/env
-      cargo clippy --all-targets --all-features -- --deny warnings --deny clippy::all --deny clippy::pedantic
+      cargo clippy --all-targets --all-features -- \
+        --deny warnings --deny clippy::all --deny clippy::pedantic
       cargo fmt --all -- --check
       tagref
       shellcheck install.sh
@@ -104,6 +106,30 @@ tasks:
       - build
       - lint
       - test
+
+  check:
+    dependencies:
+      - fetch_crates
+    input_paths:
+      - src
+    user: user
+    command: |
+      set -euo pipefail
+      . $HOME/.cargo/env
+      cargo check
+
+  format:
+    dependencies:
+      - fetch_crates
+    input_paths:
+      - src
+    output_paths:
+      - src
+    user: user
+    command: |
+      set -euo pipefail
+      . $HOME/.cargo/env
+      cargo fmt --all
 
   release:
     dependencies:


### PR DESCRIPTION
Use a custom error type rather than `String`. This allows error handling logic to respond to various types of errors differently. This decision resulted in cascading changes throughout the whole codebase. I also removed the `rustfmt.toml` file in favor of the default settings (the only difference). To embrace the new maximum line length (100, instead of 79), I manually reflowed all of the comments.

This PR also fixes an important bug that would cause failing tasks to be (incorrectly) cached.