### PR TITLE
Lint release.sh in the `lint` task

### DIFF
--- a/src/toastfile.rs
+++ b/src/toastfile.rs
@@ -138,7 +138,7 @@ fn check_paths(toastfile: &Toastfile) -> Result<(), Failure> {
                     format!(
                         "Task {} has an absolute {}: {}.",
                         name.code_str(),
-                        "ouput_path".code_str(),
+                        "output_path".code_str(),
                         path.to_string_lossy().code_str()
                     ),
                     None,

--- a/toast.yml
+++ b/toast.yml
@@ -89,6 +89,7 @@ tasks:
       - install.sh # Linted by ShellCheck
       - integration-tests # Linted by ShellCheck
       - integration-tests.sh # Linted by ShellCheck
+      - release.sh # Linted by ShellCheck
     user: user
     command: |
       set -euo pipefail
@@ -100,6 +101,7 @@ tasks:
       shellcheck install.sh
       shellcheck integration-tests.sh
       shellcheck integration-tests/**/*.sh
+      shellcheck release.sh
 
   build-test-lint:
     dependencies:


### PR DESCRIPTION
Lint release.sh in the `lint` task.

Edit: I also fixed a typo that I found with the [`misspell`](https://github.com/client9/misspell) tool.