### PR TITLE
For `--shell`, use the environment, location, and user of the last task

### DIFF
--- a/src/toastfile.rs
+++ b/src/toastfile.rs
@@ -116,7 +116,7 @@ pub fn environment<'a>(task: &'a Task) -> Result<HashMap<String, String>, Vec<&'
     }
 }
 
-// Check that environment variable names don't have `=` in them.
+// Check that environment variable names don't have `=` in them. [tag:env_var_equals]
 fn check_environment(toastfile: &Toastfile) -> Result<(), Failure> {
     for (name, task) in &toastfile.tasks {
         for variable in task.environment.keys() {


### PR DESCRIPTION
For `--shell`, use the environment, location, and user of the last task. Previously, Toast would use the empty environment, the root location, and the root user for the shell regardless of what was in the toastfile.

This PR also removes `--interactive` from the `docker container create` and `docker container start` commands, as it's not necessary now that we're no longer passing the commands to the shell via STDIN (https://github.com/stepchowfun/toast/pull/204).