### PR TITLE
Remove an unnecessary clone

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -210,7 +210,7 @@ pub fn copy_from_container(
 
         // Check if what we got from the container is a file or a directory.
         if metadata(&intermediate)
-            .map_err(system_error(&format!(
+            .map_err(system_error(format!(
                 "Unable to retrieve filesystem metadata for path {}.",
                 intermediate.to_string_lossy().code_str(),
             )))?
@@ -221,13 +221,13 @@ pub fn copy_from_container(
             let destination_dir = destination.parent().unwrap().to_owned();
 
             // Make sure the destination directory exists.
-            create_dir_all(&destination_dir).map_err(system_error(&format!(
+            create_dir_all(&destination_dir).map_err(system_error(format!(
                 "Unable to create directory {}.",
                 destination_dir.to_string_lossy().code_str(),
             )))?;
 
             // Move it to the destination.
-            rename(&intermediate, &destination).map_err(system_error(&format!(
+            rename(&intermediate, &destination).map_err(system_error(format!(
                 "Unable to move file {} to destination {}.",
                 intermediate.to_string_lossy().code_str(),
                 destination.to_string_lossy().code_str(),
@@ -236,7 +236,7 @@ pub fn copy_from_container(
             // It's a directory. Traverse it.
             for entry in WalkDir::new(&intermediate) {
                 // If we run into an error traversing the filesystem, report it.
-                let entry = entry.map_err(system_error(&format!(
+                let entry = entry.map_err(system_error(format!(
                     "Unable to traverse directory {}.",
                     intermediate.to_string_lossy().code_str(),
                 )))?;
@@ -250,13 +250,13 @@ pub fn copy_from_container(
                 // Check if the current entry is a file or a directory.
                 if entry.file_type().is_dir() {
                     // It's a directory. Create a directory at the destination.
-                    create_dir_all(&destination_path).map_err(system_error(&format!(
+                    create_dir_all(&destination_path).map_err(system_error(format!(
                         "Unable to create directory {}.",
                         destination_path.to_string_lossy().code_str(),
                     )))?;
                 } else {
                     // It's a file. Move it to the destination.
-                    rename(entry_path, &destination_path).map_err(system_error(&format!(
+                    rename(entry_path, &destination_path).map_err(system_error(format!(
                         "Unable to move file {} to destination {}.",
                         entry_path.to_string_lossy().code_str(),
                         destination_path.to_string_lossy().code_str(),
@@ -390,7 +390,7 @@ fn run_quiet(
     let output = command(args)
         .stderr(Stdio::null())
         .output()
-        .map_err(system_error(&format!(
+        .map_err(system_error(format!(
             "{} Perhaps you don't have Docker installed.",
             error
         )))?;
@@ -441,7 +441,7 @@ fn run_quiet_stdin<W: FnOnce(&mut ChildStdin) -> Result<(), Failure>>(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(system_error(&format!(
+        .map_err(system_error(format!(
             "{} Perhaps you don't have Docker installed.",
             error
         )))?;
@@ -450,7 +450,7 @@ fn run_quiet_stdin<W: FnOnce(&mut ChildStdin) -> Result<(), Failure>>(
     writer(child.stdin.as_mut().unwrap())?; // [ref:run_quiet_stdin_piped]
 
     // Wait for the child to terminate.
-    let output = child.wait_with_output().map_err(system_error(&format!(
+    let output = child.wait_with_output().map_err(system_error(format!(
         "{} Perhaps you don't have Docker installed.",
         error
     )))?;
@@ -489,13 +489,13 @@ fn run_loud(error: &str, args: &[&str], interrupted: &Arc<AtomicBool>) -> Result
     let mut child = command(args)
         .stdin(Stdio::null())
         .spawn()
-        .map_err(system_error(&format!(
+        .map_err(system_error(format!(
             "{} Perhaps you don't have Docker installed.",
             error
         )))?;
 
     // Wait for the child to terminate.
-    let status = child.wait().map_err(system_error(&format!(
+    let status = child.wait().map_err(system_error(format!(
         "{} Perhaps you don't have Docker installed.",
         error
     )))?;
@@ -522,7 +522,7 @@ fn run_attach(error: &str, args: &[&str], interrupted: &Arc<AtomicBool>) -> Resu
     let was_interrupted = interrupted.load(Ordering::SeqCst);
 
     // Run the child process.
-    let status = command(args).status().map_err(system_error(&format!(
+    let status = command(args).status().map_err(system_error(format!(
         "{} Perhaps you don't have Docker installed.",
         error
     )))?;

--- a/src/failure.rs
+++ b/src/failure.rs
@@ -35,18 +35,22 @@ impl error::Error for Failure {
     }
 }
 
-// This is a helper function to convert a `std::error::Error` into a system failure. It's written
-// in a curried style so it can be used in a higher-order fashion, e.g.,
+// This is a helper function to convert a `std::error::Error` into a system failure. It's written in
+// a curried style so it can be used in a higher-order fashion, e.g.,
 // `foo.map_err(system_error("Error doing foo."))`.
-pub fn system_error<E: error::Error + 'static>(message: &str) -> impl FnOnce(E) -> Failure {
-    let message = message.to_owned();
+pub fn system_error<S: Into<String>, E: error::Error + 'static>(
+    message: S,
+) -> impl FnOnce(E) -> Failure {
+    let message = message.into();
     move |error: E| Failure::System(message, Some(Box::new(error)))
 }
 
 // This is a helper function to convert a `std::error::Error` into a user failure. It's written in a
 // curried style so it can be used in a higher-order fashion, e.g.,
 // `foo.map_err(user_error("Error doing foo."))`.
-pub fn user_error<E: error::Error + 'static>(message: &str) -> impl FnOnce(E) -> Failure {
-    let message = message.to_owned();
+pub fn user_error<S: Into<String>, E: error::Error + 'static>(
+    message: S,
+) -> impl FnOnce(E) -> Failure {
+    let message = message.into();
     move |error: E| Failure::User(message, Some(Box::new(error)))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,7 @@ fn settings() -> Result<Settings, Failure> {
                 data
             },
         );
-    let config = config::parse(&config_data).map_err(user_error(&format!(
+    let config = config::parse(&config_data).map_err(user_error(format!(
         "Unable to parse file {}.",
         config_file_path
             .as_ref()
@@ -338,13 +338,13 @@ fn settings() -> Result<Settings, Failure> {
 // Parse a toastfile.
 fn parse_toastfile(toastfile_path: &Path) -> Result<toastfile::Toastfile, Failure> {
     // Read the file from disk.
-    let toastfile_data = fs::read_to_string(toastfile_path).map_err(user_error(&format!(
+    let toastfile_data = fs::read_to_string(toastfile_path).map_err(user_error(format!(
         "Unable to read file {}.",
         toastfile_path.to_string_lossy().code_str(),
     )))?;
 
     // Parse it.
-    toastfile::parse(&toastfile_data).map_err(user_error(&format!(
+    toastfile::parse(&toastfile_data).map_err(user_error(format!(
         "Unable to parse file {}.",
         toastfile_path.to_string_lossy().code_str()
     )))

--- a/src/tar.rs
+++ b/src/tar.rs
@@ -70,7 +70,7 @@ pub fn create<W: Write>(
 
     // Canonicalize the source directory such that other paths can be relativized with respect to
     // it.
-    let source_dir = source_dir.canonicalize().map_err(system_error(&format!(
+    let source_dir = source_dir.canonicalize().map_err(system_error(format!(
         "Unable to canonicalize path {}.",
         source_dir.to_string_lossy().code_str(),
     )))?;
@@ -106,28 +106,27 @@ pub fn create<W: Write>(
             }
 
             // Unwrap the entry.
-            let entry = entry.map_err(user_error(&format!(
+            let entry = entry.map_err(user_error(format!(
                 "Unable to traverse path {}.",
                 &absolute_input_path.to_string_lossy().code_str(),
             )))?;
 
             // Fetch the metadata for this entry.
-            let entry_metadata = entry.metadata().map_err(system_error(&format!(
+            let entry_metadata = entry.metadata().map_err(system_error(format!(
                 "Unable to fetch filesystem metadata for {}.",
                 &absolute_input_path.to_string_lossy().code_str(),
             )))?;
 
             // Fetch the host path.
-            let absolute_host_path =
-                entry.path().canonicalize().map_err(system_error(&format!(
-                    "Unable to canonicalize path {}.",
-                    &entry.path().to_string_lossy().code_str(),
-                )))?;
+            let absolute_host_path = entry.path().canonicalize().map_err(system_error(format!(
+                "Unable to canonicalize path {}.",
+                &entry.path().to_string_lossy().code_str(),
+            )))?;
 
             // Relativize the host path.
             let relative_path = absolute_host_path
                 .strip_prefix(&source_dir)
-                .map_err(system_error(&format!(
+                .map_err(system_error(format!(
                     "Unable to relativize path {} with respect to {}.",
                     &entry.path().to_string_lossy().code_str(),
                     &source_dir.to_string_lossy().code_str(),
@@ -141,7 +140,7 @@ pub fn create<W: Write>(
                 let executable = mode & 0o1 > 0 || mode & 0o10 > 0 || mode & 0o100 > 0;
 
                 // It's a file. Open it so we can compute the hash of its contents.
-                let mut file = File::open(&absolute_host_path).map_err(system_error(&format!(
+                let mut file = File::open(&absolute_host_path).map_err(system_error(format!(
                     "Unable to open file {}.",
                     &absolute_host_path.to_string_lossy().code_str(),
                 )))?;
@@ -156,11 +155,10 @@ pub fn create<W: Write>(
                 ));
 
                 // Jump back to the beginning of the file so the tar builder can read it.
-                file.seek(SeekFrom::Start(0))
-                    .map_err(system_error(&format!(
-                        "Unable to seek file {}.",
-                        &absolute_host_path.to_string_lossy().code_str(),
-                    )))?;
+                file.seek(SeekFrom::Start(0)).map_err(system_error(format!(
+                    "Unable to seek file {}.",
+                    &absolute_host_path.to_string_lossy().code_str(),
+                )))?;
 
                 // Add the file to the archive and return.
                 append(


### PR DESCRIPTION
Remove unnecessary cloning (the `to_owned()` calls in `src/failure.rs`).