### PR TITLE
Rename some functions

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,4 @@
-use crate::{
-    failure::{system_error, Failure},
-    toastfile::Task,
-};
+use crate::{failure, failure::Failure, toastfile::Task};
 use sha2::{Digest, Sha256};
 use std::{collections::HashMap, io, io::Read};
 
@@ -53,7 +50,7 @@ pub fn key(
 // data in memory at the same time.
 pub fn hash_read<R: Read>(input: &mut R) -> Result<String, Failure> {
     let mut hasher = Sha256::new();
-    io::copy(input, &mut hasher).map_err(system_error("Unable to compute hash."))?;
+    io::copy(input, &mut hasher).map_err(failure::system("Unable to compute hash."))?;
     Ok(hex::encode(hasher.result()))
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::failure::{user_error, Failure};
+use crate::{failure, failure::Failure};
 use serde::{Deserialize, Serialize};
 
 pub const REPO_DEFAULT: &str = "toast";
@@ -46,7 +46,7 @@ fn default_write_remote_cache() -> bool {
 
 // Parse a program configuration.
 pub fn parse(config: &str) -> Result<Config, Failure> {
-    serde_yaml::from_str(config).map_err(user_error("Syntax error."))
+    serde_yaml::from_str(config).map_err(failure::user("Syntax error."))
 }
 
 #[cfg(test)]

--- a/src/failure.rs
+++ b/src/failure.rs
@@ -37,20 +37,16 @@ impl error::Error for Failure {
 
 // This is a helper function to convert a `std::error::Error` into a system failure. It's written in
 // a curried style so it can be used in a higher-order fashion, e.g.,
-// `foo.map_err(system_error("Error doing foo."))`.
-pub fn system_error<S: Into<String>, E: error::Error + 'static>(
-    message: S,
-) -> impl FnOnce(E) -> Failure {
+// `foo.map_err(failure::system("Error doing foo."))`.
+pub fn system<S: Into<String>, E: error::Error + 'static>(message: S) -> impl FnOnce(E) -> Failure {
     let message = message.into();
     move |error: E| Failure::System(message, Some(Box::new(error)))
 }
 
 // This is a helper function to convert a `std::error::Error` into a user failure. It's written in a
 // curried style so it can be used in a higher-order fashion, e.g.,
-// `foo.map_err(user_error("Error doing foo."))`.
-pub fn user_error<S: Into<String>, E: error::Error + 'static>(
-    message: S,
-) -> impl FnOnce(E) -> Failure {
+// `foo.map_err(failure::user("Error doing foo."))`.
+pub fn user<S: Into<String>, E: error::Error + 'static>(message: S) -> impl FnOnce(E) -> Failure {
     let message = message.into();
     move |error: E| Failure::User(message, Some(Box::new(error)))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,7 @@ mod spinner;
 mod tar;
 mod toastfile;
 
-use crate::{
-    failure::{system_error, user_error, Failure},
-    format::CodeStr,
-};
+use crate::{failure::Failure, format::CodeStr};
 use atty::Stream;
 use clap::{App, AppSettings, Arg};
 use env_logger::{fmt::Color, Builder};
@@ -125,7 +122,7 @@ fn set_up_signal_handlers(
             let _ = stdout().write(b"\n");
         }
     })
-    .map_err(system_error("Error installing signal handler."))
+    .map_err(failure::system("Error installing signal handler."))
 }
 
 // Convert a string (from a command-line argument) into a Boolean.
@@ -233,7 +230,7 @@ fn settings() -> Result<Settings, Failure> {
     let toastfile_path = matches.value_of(TOASTFILE_ARG).map_or_else(
         || {
             let mut candidate_dir =
-                current_dir().map_err(system_error("Unable to determine working directory."))?;
+                current_dir().map_err(failure::system("Unable to determine working directory."))?;
             loop {
                 let candidate_path = candidate_dir.join(TOASTFILE_DEFAULT_NAME);
                 if let Ok(metadata) = fs::metadata(&candidate_path) {
@@ -282,7 +279,7 @@ fn settings() -> Result<Settings, Failure> {
                 data
             },
         );
-    let config = config::parse(&config_data).map_err(user_error(format!(
+    let config = config::parse(&config_data).map_err(failure::user(format!(
         "Unable to parse file {}.",
         config_file_path
             .as_ref()
@@ -338,13 +335,13 @@ fn settings() -> Result<Settings, Failure> {
 // Parse a toastfile.
 fn parse_toastfile(toastfile_path: &Path) -> Result<toastfile::Toastfile, Failure> {
     // Read the file from disk.
-    let toastfile_data = fs::read_to_string(toastfile_path).map_err(user_error(format!(
+    let toastfile_data = fs::read_to_string(toastfile_path).map_err(failure::user(format!(
         "Unable to read file {}.",
         toastfile_path.to_string_lossy().code_str(),
     )))?;
 
     // Parse it.
-    toastfile::parse(&toastfile_data).map_err(user_error(format!(
+    toastfile::parse(&toastfile_data).map_err(failure::user(format!(
         "Unable to parse file {}.",
         toastfile_path.to_string_lossy().code_str()
     )))


### PR DESCRIPTION
Rename some functions. Specifically, `system_error` -> `system` and `user_error` -> `user`. These functions are in the `failure` module and are intended to be used by their fully qualified names (`failure::system` and `failure::user`).