### PR TITLE
In the release script, don't assume the location of Bash

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # This script generates release artifacts in a directory called `release`. It should be run from a


### PR DESCRIPTION
In the release script, don't assume the location of Bash.