### PR TITLE
Introduce the `--list` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] - 2019-05-29
+
+### Added
+- Added the `--list` option to list all the tasks in the toastfile.
+- Added the `description` task field to be shown to the user when `--list` is used.
+
 ## [0.21.0] - 2019-05-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 description = "Containerize your development environment."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -267,20 +267,21 @@ A *toastfile* is a YAML file (typically named `toast.yml`) that defines tasks an
 
 ```yaml
 image:   <Docker image name with optional tag or digest>
-default: <name of default task to run or null to run all tasks by default>
+default: <name of default task to run or `null` to run all tasks by default>
 tasks:   <map from task name to task>
 ```
 
 Tasks have the following schema and defaults:
 
 ```yaml
+description: null     # A description of the task for the `--list` option
 dependencies: []      # Names of dependencies
 cache: true           # Whether a task can be cached
 environment: {}       # Map from environment variable to optional default
 input_paths: []       # Paths to copy into the container
 output_paths: []      # Paths to copy out of the container
 mount_paths: []       # Paths to mount into the container
-mount_readonly: false # Whether to mount the mount_paths as readonly
+mount_readonly: false # Whether to mount the `mount_paths` as readonly
 ports: []             # Port mappings to publish
 location: /scratch    # Path in the container for running this task
 user: root            # Name of the user in the container for running this task
@@ -338,6 +339,9 @@ OPTIONS:
 
     -h, --help
             Prints help information
+
+    -l, --list
+            Lists the tasks in the toastfile
 
         --read-local-cache <BOOL>
             Sets whether local cache reading is enabled

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -80,6 +80,7 @@ mod tests {
         let previous_key = "corge";
 
         let task = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment,
@@ -110,6 +111,7 @@ mod tests {
         let previous_key2 = "bar";
 
         let task = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: HashMap::new(),
@@ -146,6 +148,7 @@ mod tests {
         let previous_key = "corge";
 
         let task1 = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: environment1,
@@ -160,6 +163,7 @@ mod tests {
         };
 
         let task2 = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: environment2,
@@ -196,6 +200,7 @@ mod tests {
         let previous_key = "corge";
 
         let task1 = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: environment1,
@@ -210,6 +215,7 @@ mod tests {
         };
 
         let task2 = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: environment2,
@@ -243,6 +249,7 @@ mod tests {
         let previous_key = "corge";
 
         let task = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment,
@@ -274,6 +281,7 @@ mod tests {
         let previous_key = "corge";
 
         let task = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: HashMap::new(),
@@ -303,6 +311,7 @@ mod tests {
         let previous_key = "corge";
 
         let task1 = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: HashMap::new(),
@@ -317,6 +326,7 @@ mod tests {
         };
 
         let task2 = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: HashMap::new(),
@@ -345,6 +355,7 @@ mod tests {
         let previous_key = "corge";
 
         let task1 = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: HashMap::new(),
@@ -359,6 +370,7 @@ mod tests {
         };
 
         let task2 = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: HashMap::new(),
@@ -387,6 +399,7 @@ mod tests {
         let previous_key = "corge";
 
         let task1 = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: HashMap::new(),
@@ -401,6 +414,7 @@ mod tests {
         };
 
         let task2 = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: HashMap::new(),
@@ -429,6 +443,7 @@ mod tests {
         let previous_key = "corge";
 
         let task1 = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: HashMap::new(),
@@ -443,6 +458,7 @@ mod tests {
         };
 
         let task2 = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: HashMap::new(),

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -83,6 +83,7 @@ mod tests {
 
     fn task_with_dependencies(dependencies: Vec<String>) -> Task {
         Task {
+            description: None,
             dependencies,
             cache: true,
             environment: HashMap::new(),

--- a/src/toastfile.rs
+++ b/src/toastfile.rs
@@ -16,6 +16,8 @@ pub const DEFAULT_USER: &str = "root";
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Task {
+    pub description: Option<String>,
+
     #[serde(default)]
     pub dependencies: Vec<String>,
 
@@ -439,6 +441,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -476,6 +479,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -521,6 +525,7 @@ image: encom:os-12
 tasks:
   foo: {}
   bar:
+    description: Reticulate splines.
     dependencies:
       - foo
     cache: false
@@ -560,6 +565,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -576,6 +582,7 @@ tasks:
         tasks.insert(
             "bar".to_owned(),
             Task {
+                description: Some("Reticulate splines.".to_owned()),
                 dependencies: vec!["foo".to_owned()],
                 cache: false,
                 environment,
@@ -614,6 +621,7 @@ tasks:
     #[test]
     fn environment_empty() {
         let task = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: HashMap::new(),
@@ -638,6 +646,7 @@ tasks:
         env_map.insert("foo1".to_owned(), Some("bar".to_owned()));
 
         let task = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: env_map,
@@ -667,6 +676,7 @@ tasks:
         env_map.insert("foo2".to_owned(), Some("bar".to_owned()));
 
         let task = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: env_map,
@@ -696,6 +706,7 @@ tasks:
         env_map.insert("foo3".to_owned(), None);
 
         let task = Task {
+            description: None,
             dependencies: vec![],
             cache: true,
             environment: env_map,
@@ -722,6 +733,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -756,6 +768,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment,
@@ -790,6 +803,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment,
@@ -821,6 +835,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -850,6 +865,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -879,6 +895,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -910,6 +927,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -941,6 +959,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -972,6 +991,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -1003,6 +1023,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -1034,6 +1055,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -1063,6 +1085,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -1094,6 +1117,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: false,
                 environment: HashMap::new(),
@@ -1123,6 +1147,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -1154,6 +1179,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: false,
                 environment: HashMap::new(),
@@ -1194,6 +1220,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -1223,6 +1250,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -1239,6 +1267,7 @@ tasks:
         tasks.insert(
             "bar".to_owned(),
             Task {
+                description: None,
                 dependencies: vec!["foo".to_owned()],
                 cache: true,
                 environment: HashMap::new(),
@@ -1268,6 +1297,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec![],
                 cache: true,
                 environment: HashMap::new(),
@@ -1284,6 +1314,7 @@ tasks:
         tasks.insert(
             "bar".to_owned(),
             Task {
+                description: None,
                 dependencies: vec!["foo".to_owned(), "baz".to_owned()],
                 cache: true,
                 environment: HashMap::new(),
@@ -1315,6 +1346,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec!["foo".to_owned()],
                 cache: true,
                 environment: HashMap::new(),
@@ -1346,6 +1378,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec!["bar".to_owned()],
                 cache: true,
                 environment: HashMap::new(),
@@ -1362,6 +1395,7 @@ tasks:
         tasks.insert(
             "bar".to_owned(),
             Task {
+                description: None,
                 dependencies: vec!["foo".to_owned()],
                 cache: true,
                 environment: HashMap::new(),
@@ -1393,6 +1427,7 @@ tasks:
         tasks.insert(
             "foo".to_owned(),
             Task {
+                description: None,
                 dependencies: vec!["baz".to_owned()],
                 cache: true,
                 environment: HashMap::new(),
@@ -1409,6 +1444,7 @@ tasks:
         tasks.insert(
             "bar".to_owned(),
             Task {
+                description: None,
                 dependencies: vec!["foo".to_owned()],
                 cache: true,
                 environment: HashMap::new(),
@@ -1425,6 +1461,7 @@ tasks:
         tasks.insert(
             "baz".to_owned(),
             Task {
+                description: None,
                 dependencies: vec!["bar".to_owned()],
                 cache: true,
                 environment: HashMap::new(),


### PR DESCRIPTION
Introduce the `--list` option for listing all the tasks in the toastfile. I also added a `description` task field which is included in the `--list` output. This is what it looks like in my terminal:

<img width="932" alt="Screenshot 2019-05-29 22 41 52" src="https://user-images.githubusercontent.com/796574/58611158-f9bf9900-8262-11e9-984c-0864f0bde89f.png">

cc @bobhenkel @filipekiss @juliahw

**Status:** Ready

**Fixes:** https://github.com/stepchowfun/toast/issues/223
