### PR TITLE
Fix a bug that would cause the `output_files` feature to fail if `/tmp` on the host is on a different mounted filesystem than the destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.0] - 2019-05-31
+
+### Fixed
+- Fixed a bug that would cause the `output_files` feature to fail if `/tmp` on the host is on a different mounted filesystem than the destination.
+
 ## [0.22.0] - 2019-05-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 description = "Containerize your development environment."
 license = "MIT"


### PR DESCRIPTION
Fix a bug that would cause the `output_files` feature to fail if `/tmp` on the host is on a different mounted filesystem than the destination. The comment contains additional information about this bug. Thanks to @kbknapp for reporting it.

**Status:** Ready

**Fixes:** https://github.com/stepchowfun/toast/issues/239
