### PR TITLE
Make the `check` task more useful

### DIFF
--- a/toast.yml
+++ b/toast.yml
@@ -129,7 +129,7 @@ tasks:
     command: |
       set -euo pipefail
       . $HOME/.cargo/env
-      cargo check
+      cargo check --all --all-targets --all-features
 
   format:
     description: Format the source code.


### PR DESCRIPTION
Make the `check` task more useful. It will now also check tests, whereas before it only checked the source code without the tests.

**Status:** Ready

**Fixes:** N/A
