### PR TITLE
Formalize the guarantees of the hashing functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0] - 2019-06-02
+
+### Changed
+- This release contains only internal improvements to the robustness of the code. Upgrading to this new version will invalidate existing cached tasks.
+
 ## [0.23.0] - 2019-05-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 description = "Containerize your development environment."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ mount_readonly: false # Whether to mount the `mount_paths` as readonly
 ports: []             # Port mappings to publish
 location: /scratch    # Path in the container for running this task
 user: root            # Name of the user in the container for running this task
-command: null         # Shell command to run in the container
+command: ''           # Shell command to run in the container
 ```
 
 The [toastfile](https://github.com/stepchowfun/toast/blob/master/toast.yml) for Toast itself is a comprehensive real-world example.

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -105,7 +105,7 @@ pub fn create_container(
 
     let mut mount_options = Vec::new();
     for path in mount_paths {
-        // [ref:mount_path_comma]
+        // [ref:mount_paths_no_commas]
         if mount_readonly {
             mount_options.push(format!(
                 "type=bind,source={},target={},readonly",
@@ -204,14 +204,13 @@ pub fn copy_from_container(
         );
 
         // `docker container cp` is not idempotent. For example, suppose there is a directory called
-        // `/foo` in the container and `/bar` does not exist on the host. Consider the following
-        // command:
-        //   `docker cp container:/foo /bar`
-        // The first time that command is run, Docker will create the directory `/bar` on the host
-        // and copy the files from `/foo` into it. But if you run it again, Docker will copy `/bar`
-        // into the directory `/foo`, resulting in `/foo/foo`, which is undesirable. To work around
-        // this, we first copy the path from the container into a temporary directory (where the
-        // target path is guaranteed to not exist). Then we copy/move that to the final destination.
+        // `/foo` in the container and `/bar` does not exist on the host. Consider the command
+        // `docker cp container:/foo /bar`. The first time that command is run, Docker will create
+        // the directory `/bar` on the host and copy the files from `/foo` into it. But if you run
+        // it again, Docker will copy `/bar` into the directory `/foo`, resulting in `/foo/foo`,
+        // which is undesirable. To work around this, we first copy the path from the container into
+        // a temporary directory (where the target path is guaranteed to not exist). Then we
+        // copy/move that path to the final destination.
         let temp_dir =
             tempdir().map_err(failure::system("Unable to create temporary directory."))?;
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -30,7 +30,7 @@ pub fn number(n: usize, noun: &str) -> String {
 // (and an Oxford comma, if applicable) between the last two items.
 pub fn series(items: &[String]) -> String {
     match items.len() {
-        0 => "".to_owned(),
+        0 => String::new(),
         1 => items[0].clone(),
         2 => format!("{} and {}", items[0], items[1]),
         _ => format!(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -139,9 +139,7 @@ pub fn run(
                 &task.ports,
                 &task.location,
                 &task.user,
-                task.command
-                    .as_ref()
-                    .map_or("true", |command| command as &str),
+                &task.command,
                 interrupted,
             ) {
                 Ok(container) => container,
@@ -198,9 +196,7 @@ pub fn run(
             &task.ports,
             &task.location,
             &task.user,
-            task.command
-                .as_ref()
-                .map_or("true", |command| command as &str),
+            &task.command,
             interrupted,
         ) {
             Ok(container) => container,

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -94,7 +94,7 @@ mod tests {
             ports: vec![],
             location: Path::new(DEFAULT_LOCATION).to_owned(),
             user: DEFAULT_USER.to_owned(),
-            command: None,
+            command: String::new(),
         }
     }
 

--- a/src/tar.rs
+++ b/src/tar.rs
@@ -146,8 +146,8 @@ pub fn create<W: Write>(
                     )))?;
 
                 // Compute the hash of the file contents and metadata.
-                file_hashes.push(cache::extend(
-                    &cache::extend(
+                file_hashes.push(cache::combine(
+                    &cache::combine(
                         &cache::hash_str(&relative_path.to_string_lossy()),
                         &cache::hash_read(&mut file)?,
                     ),
@@ -197,6 +197,6 @@ pub fn create<W: Write>(
             .map_err(failure::system("Error writing tar archive."))?,
         file_hashes
             .iter()
-            .fold(cache::hash_str(""), |acc, x| cache::extend(&acc, x)),
+            .fold(String::new(), |acc, x| cache::combine(&acc, x)),
     ))
 }


### PR DESCRIPTION
Formalize the guarantees of the hashing functions. Unfortunately, upgrading to this new version will invalidate existing cached tasks, but the internal code improvements that caused this are worth it:

- Introduced `CACHE_VERSION`, which allows us to invalidate the all existing caches if necessary (should be extremely rare)
- Fixed a hypothetical future issue that currently can't happen (by a sheer coincidence) but a seemingly innocent code change could have easily enabled it. The issue would cause two distinct tasks to have the same cache key when they shouldn't (which could cause Toast to incorrectly skip a task). This would happen due to the way the cache keys were computed.

I also refactored a lot of the logic in `toastfile.rs` for long-term maintainability, making heavy use of [Tagref](https://github.com/stepchowfun/tagref).

**Status:** Ready

**Fixes:** N/A
