### PR TITLE
Fix a bug that prevented the standard error output from being logged if a child process failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.0] - 2019-06-09
+
+### Fixed
+- Fixed the way symlinks in `input_paths` are handled.
+- Fix a bug that prevented the standard error output from being logged if a child process failed.
+
 ## [0.24.0] - 2019-06-02
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 description = "Containerize your development environment."
 license = "MIT"


### PR DESCRIPTION
Fix a bug that prevented the standard error output from being logged if a child process failed. This made it difficult to diagnose issues like Docker client permissions issues. Thanks to @CodeGradox for reporting this problem in https://github.com/stepchowfun/toast/issues/246.

**Status:** Ready

**Fixes:** https://github.com/stepchowfun/toast/issues/246
