### PR TITLE
Fix a bug that would cause Toast to crash if the first task had no environment variables, no input paths, and no command to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.0] - 2019-06-09
+
+### Fixed
+- Fixed a bug that would cause Toast to crash if the first task had no environment variables, no input paths, and no command to run.
+
 ## [0.26.0] - 2019-06-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 description = "Containerize your development environment."
 license = "MIT"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -63,7 +63,12 @@ pub fn hash_read<R: Read>(input: &mut R) -> Result<String, Failure> {
     Ok(hex::encode(hasher.result()))
 }
 
-// Determine the cache ID of a task based on the cache ID of the previous task in the schedule (or
+// Determine the initial cache key. [ref:cache_prefix]
+pub fn initial_key(image: &str) -> String {
+    format!("toast-{}", image.crypto_hash())
+}
+
+// Determine the cache key of a task based on the cache key of the previous task in the schedule (or
 // the hash of the base image, if this is the first task).
 pub fn key(
     previous_key: &str,
@@ -74,8 +79,8 @@ pub fn key(
     // Start with the previous key.
     let mut cache_key: String = previous_key.to_owned();
 
-    // If there are no environment variables, no input paths, no command to run, we can just use the
-    // cache key from the previous task.
+    // If there are no environment variables, no input paths, and no command to run, we can just use
+    // the cache key from the previous task.
     if task.environment.is_empty() && task.input_paths.is_empty() && task.command.is_empty() {
         return cache_key;
     }
@@ -110,6 +115,7 @@ pub fn key(
 
     // We add this "toast-" prefix because Docker has a rule that tags cannot be 64-byte hexadecimal
     // strings. See this for more details: https://github.com/moby/moby/issues/20972
+    // [tag:cache_prefix]
     format!("toast-{}", cache_key)
 }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -299,31 +299,35 @@ pub fn copy_from_container(
 
                 // Figure out what needs to go where. The `unwrap` is safe because `entry` is
                 // guaranteed to be inside `intermediate` (or equal to it).
-                let entry_path = entry.path();
-                let destination_path =
-                    destination.join(entry_path.strip_prefix(&intermediate).unwrap());
+                let entry_source_path = entry.path();
+                let entry_destination_path =
+                    destination.join(entry_source_path.strip_prefix(&intermediate).unwrap());
 
                 // Check if the entry is a file or a directory.
                 if entry.file_type().is_dir() {
                     // It's a directory. Create a directory at the destination.
-                    create_dir_all(&destination_path).map_err(failure::system(format!(
+                    create_dir_all(&entry_destination_path).map_err(failure::system(format!(
                         "Unable to create directory {}.",
-                        destination_path.to_string_lossy().code_str(),
+                        entry_destination_path.to_string_lossy().code_str(),
                     )))?;
                 } else {
                     // It's a file or symlink. Move or copy it to the destination.
-                    rename_or_copy_file_or_symlink(entry_path, &destination_path, &entry_metadata)?;
+                    rename_or_copy_file_or_symlink(
+                        entry_source_path,
+                        &entry_destination_path,
+                        &entry_metadata,
+                    )?;
                 }
             }
         } else {
             // It's a file or symlink. Determine the destination directory. The `unwrap` is safe
             // because the root of the filesystem cannot be a file or symlink.
-            let destination_dir = destination.parent().unwrap().to_owned();
+            let destination_parent = destination.parent().unwrap().to_owned();
 
             // Make sure the destination directory exists.
-            create_dir_all(&destination_dir).map_err(failure::system(format!(
+            create_dir_all(&destination_parent).map_err(failure::system(format!(
                 "Unable to create directory {}.",
-                destination_dir.to_string_lossy().code_str(),
+                destination_parent.to_string_lossy().code_str(),
             )))?;
 
             // Move or copy it to the destination.

--- a/src/main.rs
+++ b/src/main.rs
@@ -464,8 +464,8 @@ fn run_tasks(
     // `false`.
     let mut caching_enabled = true;
 
-    // This is the cache key for the current task. We initialize it with the base image name.
-    let mut cache_key = toastfile.image.clone();
+    // This is the cache key for the current task.
+    let mut cache_key = cache::initial_key(&toastfile.image);
 
     // We start with the base image.
     let mut context = runner::Context {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -18,7 +18,7 @@ pub fn compute<'a>(toastfile: &'a Toastfile, tasks: &[&'a str]) -> Vec<&'a str> 
     // For each root, compute its transitive reflexive closure, topsort it, and add it to the
     // schedule.
     for root in roots {
-        // The frontier is a stack, which means we are doing a depth-first traversal.
+        // We'll this frontier as a stack for a depth-first traversal.
         let mut frontier: Vec<(&'a str, bool)> = vec![(root, true)];
 
         // This vector will accumulate the topsorted tasks.


### PR DESCRIPTION
Fix a bug that would cause Toast to crash if the first task had no environment variables, no input paths, and no command to run.

**Status:** Ready

**Fixes:** N/A
