### PR TITLE
support relative paths for input_paths

### DIFF
--- a/integration-tests/input-paths/dir-relative/run.sh
+++ b/integration-tests/input-paths/dir-relative/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir ../foo
+"$TOAST" --read-local-cache false --write-local-cache false > output.txt
+grep 'drwxrwxrwx .* root root .* foo' output.txt
+rm output.txt
+rm -r ../foo

--- a/integration-tests/input-paths/dir-relative/toast.yml
+++ b/integration-tests/input-paths/dir-relative/toast.yml
@@ -1,0 +1,9 @@
+image: debian
+tasks:
+  list:
+    input_paths:
+      - ../foo
+    command: |
+      set -euo pipefail
+      ls -al
+      ls -al foo

--- a/src/tar.rs
+++ b/src/tar.rs
@@ -1,11 +1,11 @@
 use crate::{cache, cache::CryptoHash, failure, failure::Failure, format::CodeStr, spinner::spin};
 use std::{
     collections::HashSet,
+    ffi::OsStr,
     fs::{read_link, symlink_metadata, File, Metadata},
     io::{empty, Read, Seek, SeekFrom, Write},
     os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
-    ffi::OsStr,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -277,13 +277,17 @@ pub fn create<W: Write>(
                     &mut visited_paths,
                     entry.path(),
                     strip_root(
-                        &destination_dir.join(entry.path().strip_prefix(&source_dir).map_err(
-                            failure::system(format!(
-                                "Unable to relativize path {} with respect to {}.",
-                                entry.path().to_string_lossy().code_str(),
-                                source_dir.to_string_lossy().code_str(),
-                            )),
-                        ).map(|p| strip_relative(p))?),
+                        &destination_dir.join(
+                            entry
+                                .path()
+                                .strip_prefix(&source_dir)
+                                .map_err(failure::system(format!(
+                                    "Unable to relativize path {} with respect to {}.",
+                                    entry.path().to_string_lossy().code_str(),
+                                    source_dir.to_string_lossy().code_str(),
+                                )))
+                                .map(|p| strip_relative(p))?,
+                        ),
                     ),
                     &entry_metadata,
                 )?;
@@ -296,13 +300,16 @@ pub fn create<W: Write>(
                 &mut visited_paths,
                 &input_path,
                 strip_root(
-                    &destination_dir.join(input_path.strip_prefix(&source_dir).map_err(
-                        failure::system(format!(
-                            "Unable to relativize path {} with respect to {}.",
-                            input_path.to_string_lossy().code_str(),
-                            source_dir.to_string_lossy().code_str(),
-                        )),
-                    ).map(|p| strip_relative(p))?),
+                    &destination_dir.join(
+                        input_path
+                            .strip_prefix(&source_dir)
+                            .map_err(failure::system(format!(
+                                "Unable to relativize path {} with respect to {}.",
+                                input_path.to_string_lossy().code_str(),
+                                source_dir.to_string_lossy().code_str(),
+                            )))
+                            .map(|p| strip_relative(p))?,
+                    ),
                 ),
                 &input_path_metadata,
             )?;


### PR DESCRIPTION
Support relative paths in input_paths. Right now if you try to use "../foo" in input_paths the tar module will give an error.