### PR TITLE
For interactive shells, inherit all the container settings from the last task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.0] - 2019-06-30
+
+### Changed
+- The container used for the `--shell` feature now uses the mount settings and ports from the last executed task, if any.
+
 ## [0.27.0] - 2019-06-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 description = "Containerize your development environment."
 license = "MIT"


### PR DESCRIPTION
For interactive shells, inherit all the container settings from the last task. Before this change, only the environment, location, and user were inherited. This change adds mount path and port settings as well.

**Status:** Ready

**Fixes:** https://github.com/stepchowfun/toast/issues/261
