### PR TITLE
Change a semicolon to a period

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ pub struct Settings {
     tasks: Option<Vec<String>>,
 }
 
-// Parse the command-line arguments;
+// Parse the command-line arguments.
 fn settings() -> Result<Settings, Failure> {
     let matches = App::new("Toast")
         .version(VERSION)


### PR DESCRIPTION
Change a semicolon to a period. It was a typo.

**Status:** Ready

**Fixes:** N/A
