### PR TITLE
Allow `mount_paths` to be absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.0] - 2019-07-11
+
+### Changed
+- `mount_paths` are now allowed to be absolute. This is to support mounting the Docker IPC socket (usually located at `/var/run/docker.sock`) in the container for running Docker commands in tasks.
+
 ## [0.28.0] - 2019-06-30
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 description = "Containerize your development and continuous integration environments."
 license = "MIT"


### PR DESCRIPTION
Allow `mount_paths` to be absolute. This is to support mounting the Docker IPC socket (usually located at `/var/run/docker.sock`) in the container for running Docker commands in tasks.

Example toastfile:

```yml
image: ubuntu
tasks:
  install_docker:
    command: |
      apt-get update
      apt-get install --yes curl
      curl -fsSL https://get.docker.com | sh
  run_container:
    cache: false
    mount_paths:
      - /var/run/docker.sock
    command: docker run hello-world
```

Output before this change:

```sh
$ toast
[ERROR] Unable to parse file toast.yml. Reason: Task run_container has an absolute mount_path: /var/run/docker.sock.
```

Output after this change:

```sh
$ toast
[INFO] Ready to run 2 tasks: install_docker and run_docker.
[INFO] Running task install_docker…
[INFO] Running task run_docker…

Hello from Docker!
This message shows that your installation appears to be working correctly.

To generate this message, Docker took the following steps:
 1. The Docker client contacted the Docker daemon.
 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
    (amd64)
 3. The Docker daemon created a new container from that image which runs the
    executable that produces the output you are currently reading.
 4. The Docker daemon streamed that output to the Docker client, which sent it
    to your terminal.

To try something more ambitious, you can run an Ubuntu container with:
 $ docker run -it ubuntu bash

Share images, automate workflows, and more with a free Docker ID:
 https://hub.docker.com/

For more examples and ideas, visit:
 https://docs.docker.com/get-started/
```

cc @bobhenkel

**Status:** Ready

**Fixes:** https://github.com/stepchowfun/toast/issues/225
