### PR TITLE
Upgrade Rust to version 1.39.0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,7 @@ pub struct Settings {
 }
 
 // Parse the command-line arguments.
+#[allow(clippy::too_many_lines)]
 fn settings() -> Result<Settings, Failure> {
     let matches = App::new("Toast")
         .version(VERSION)
@@ -520,6 +521,7 @@ fn run_tasks(
 }
 
 // Program entrypoint
+#[allow(clippy::too_many_lines)]
 fn entry() -> Result<(), Failure> {
     // Determine whether to print colored output.
     colored::control::set_override(atty::is(Stream::Stdout));

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -31,6 +31,7 @@ impl Drop for Context {
 
 // Run a task and return the new cache key.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
 pub fn run(
     settings: &super::Settings,
     environment: &HashMap<String, String>,

--- a/src/toastfile.rs
+++ b/src/toastfile.rs
@@ -146,6 +146,7 @@ pub fn environment<'a>(task: &'a Task) -> Result<HashMap<String, String>, Vec<&'
 }
 
 // Check that all dependencies exist and form a DAG (no cycles).
+#[allow(clippy::too_many_lines)]
 fn check_dependencies<'a>(toastfile: &'a Toastfile) -> Result<(), Failure> {
     // Check the default task. [tag:valid_default]
     let valid_default = toastfile

--- a/toast.yml
+++ b/toast.yml
@@ -32,7 +32,7 @@ tasks:
     command: |
       set -euo pipefail
       curl https://sh.rustup.rs -sSf |
-        sh -s -- -y --default-toolchain 1.38.0
+        sh -s -- -y --default-toolchain 1.39.0
       . $HOME/.cargo/env
       rustup component add clippy
       rustup component add rustfmt


### PR DESCRIPTION
Upgrade Rust to version 1.39.0.

**Status:** Ready

**Fixes:** N/A
