### PR TITLE
Add a helpful comment explaining the motivation for the `CodeStr` trait

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -2,6 +2,9 @@ use atty::Stream;
 use colored::{ColoredString, Colorize};
 
 // This trait has a function for formatting "code-like" text, such as a task name or a file path.
+// The reason it's implemented as a trait and not just a function is so we can use it with method
+// syntax, as in `x.code_str()`. Rust does not allow us to implement methods on primitive types
+// such as `str`.
 pub trait CodeStr {
     fn code_str(&self) -> ColoredString;
 }


### PR DESCRIPTION
Add a helpful comment explaining the motivation for the `CodeStr` trait.

**Status:** Ready

**Fixes:** N/A
