### PR TITLE
Have a single source of truth for whether to print colored output

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -1,5 +1,4 @@
-use atty::Stream;
-use colored::{ColoredString, Colorize};
+use colored::{control::SHOULD_COLORIZE, ColoredString, Colorize};
 
 // This trait has a function for formatting "code-like" text, such as a task name or a file path.
 // The reason it's implemented as a trait and not just a function is so we can use it with method
@@ -14,7 +13,9 @@ impl CodeStr for str {
     // disable it here.
     #![allow(clippy::use_self)]
     fn code_str(&self) -> ColoredString {
-        if atty::is(Stream::Stdout) {
+        // If colored output is enabled, format the text in magenta. Otherwise, surround it in
+        // backticks.
+        if SHOULD_COLORIZE.should_colorize() {
             self.magenta()
         } else {
             ColoredString::from(&format!("`{}`", self) as &Self)


### PR DESCRIPTION
Have a single source of truth for whether to print colored output.

**Status:** Ready

**Fixes:** N/A
