### PR TITLE
Remove the broken GitHub workflow badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Toast 🥂
 
-[![Build status](https://github.com/actions/toast/workflows/Continuous%20integration/badge.svg)](https://github.com/stepchowfun/toast/actions)
-
 *Toast* is a tool for doing work in containers. You define tasks in a YAML file called a *toastfile*, and Toast runs them in a containerized environment based on a Docker image of your choosing. What constitutes a "task" is up to you: tasks can install system packages, build an application, run a test suite, or even serve web pages.
 
 ![Welcome to Toast.](https://raw.githubusercontent.com/stepchowfun/toast/master/media/welcome-0.svg?sanitize=true)


### PR DESCRIPTION
Remove the broken GitHub workflow badge from the README.

**Status:** Ready

**Fixes:** N/A
