### PR TITLE
Windows host initial support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
   ci:
     runs-on: ubuntu-latest
+    name: build, check, unit test, and integration test on linux
     steps:
     - uses: actions/checkout@v2
     - uses: azure/docker-login@v1
@@ -17,3 +18,31 @@ jobs:
         write_remote_cache: ${{ github.event_name == 'push' }}
     - name: Run integration tests
       run: TOAST="$(pwd)/artifacts/toast-x86_64-unknown-linux-gnu" ./integration-tests.sh
+  windows_ci:
+    name: build and unit test on windows
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: cargo build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --target=x86_64-pc-windows-msvc --release --all-features
+    - name: cargo test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --target=x86_64-pc-windows-msvc --release --all-features

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,7 +4,6 @@ use std::{
     collections::HashMap,
     io,
     io::Read,
-    os::unix::ffi::OsStrExt,
     path::{Path, PathBuf},
 };
 
@@ -32,15 +31,28 @@ impl CryptoHash for String {
     }
 }
 
+#[cfg(unix)]
+fn path_as_bytes(path: &Path) -> &[u8] {
+    use std::os::unix::ffi::OsStrExt;
+    path.as_os_str().as_bytes()
+}
+#[cfg(windows)]
+fn path_as_bytes(path: &Path) -> &[u8] {
+    path.as_os_str()
+        .to_str()
+        .map(|s| s.as_bytes())
+        .expect("Invalid UTF8")
+}
+
 impl CryptoHash for Path {
     fn crypto_hash(&self) -> String {
-        hex::encode(Sha256::digest(self.as_os_str().as_bytes()))
+        hex::encode(Sha256::digest(path_as_bytes(&self)))
     }
 }
 
 impl CryptoHash for PathBuf {
     fn crypto_hash(&self) -> String {
-        hex::encode(Sha256::digest(self.as_os_str().as_bytes()))
+        hex::encode(Sha256::digest(path_as_bytes(&self)))
     }
 }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -4,7 +4,6 @@ use std::{
     fs::{copy, create_dir_all, read_link, rename, symlink_metadata, Metadata},
     io,
     io::Read,
-    os::unix::fs::symlink,
     path::{Path, PathBuf},
     process::{ChildStdin, Command, Stdio},
     string::ToString,
@@ -191,11 +190,23 @@ fn rename_or_copy_file_or_symlink(
                 source_path.to_string_lossy().code_str(),
             )))?;
 
+            #[cfg(unix)]
             // Create a copy of the symlink at the destination.
-            symlink(target_path, destination_path).map_err(failure::system(format!(
-                "Unable to create symbolic link at {}.",
-                destination_path.to_string_lossy().code_str(),
-            )))?;
+            std::os::unix::fs::symlink(target_path, destination_path).map_err(failure::system(
+                format!(
+                    "Unable to create symbolic link at {}.",
+                    destination_path.to_string_lossy().code_str(),
+                ),
+            ))?;
+            #[cfg(not(unix))]
+            return Err(failure::Failure::System(
+                format!(
+                    "Creation of symbolic link is not supported on Windows yet. Source path: {:?}, target path: {:?}",
+                    source_path,
+                    target_path
+                ),
+                None
+            ));
         } else {
             // It's a file. Copy it to the destination.
             copy(source_path, destination_path).map_err(failure::system(format!(


### PR DESCRIPTION
This PR resurrects #285 by performing the rebase onto master and `cargo fmt`, in addition to @qthree 's initial work on windows support. GitHub actions runs cargo build and test with windows virtual machine environment. Windows builds from scratch because no pre-existing deployments exist, but a cache is used to improve CI performance.

Extra notes:
I attempted to get integration tests running in GitHub actions, but ran into technical hurdles that would have required more creative solutions and would be bigger than this PR. The Windows virtual machine environment can not easily run linux containers because it requires extra linux VM infrastructure. Running integration tests can still be achieved, but it would require a different CI tool. `cargo test` may need to be a sufficient substitute for now. 

This doesn't exactly mirror the linux build step because it's not dog-fooding in the same way by pulling down an already existing published binary for `toast`. This PR stays clear of `cargo publish` because I imagine the maintainer may be interested in taking a specific approach. Follow up work will still be needed to make this new binary executable available to the general user via GitHub release and/or conventional delivery tools on windows e.g. npm, chocolatey, or windows package manager.

Fixes #262 .