### PR TITLE
Install the latest version of Tagref

### DIFF
--- a/toast.yml
+++ b/toast.yml
@@ -14,8 +14,7 @@ tasks:
       - install_packages
     command: |
       set -euo pipefail
-      curl https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh -LSfs |
-        VERSION=1.2.1 sh
+      curl https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh -LSfs | sh
 
   create_user:
     description: Create a user who doesn't have root privileges.


### PR DESCRIPTION
Install the latest version of Tagref rather than a specific pinned version. The interface is stable, so pinning is unnecessary and comes with the slight maintenance burden of keeping it up to date.

**Status:** Ready

**Fixes:** N/A
