### PR TITLE
Skip committing the container when a task is interrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.0] - 2021-08-21
+
+### Changed
+- Toast no longer wastes time committing the container when a task is interrupted (e.g., by hitting CTRL+C).
+
 ## [0.41.0] - 2021-08-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.41.0"
+version = "0.42.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "Containerize your development and continuous integration environments."


### PR DESCRIPTION
Skip committing the container when a task is interrupted.

**Status:** Ready

**Fixes:** N/A
