### PR TITLE
Rename `--repo` to `--docker-repo`

### DIFF
--- a/.github/actions/toast/action.yml
+++ b/.github/actions/toast/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'The location of the toastfile relative to the repository root'
     required: true
     default: ''
-  repo:
+  docker_repo:
     description: 'The Docker repository for remote caching'
     required: true
     default: ''
@@ -17,6 +17,9 @@ inputs:
     description: 'Whether to write to the Docker repository for remote caching'
     required: true
     default: 'false'
+  repo:
+    description: 'Deprecated. Use `docker_repo` instead.'
+    required: false
 runs:
   using: node12
   main: index.js

--- a/.github/actions/toast/index.js
+++ b/.github/actions/toast/index.js
@@ -6,13 +6,13 @@ const { v4: uuidv4 } = require('uuid');
 // Read the action inputs.
 const tasksInput = core.getInput('tasks').trim();
 const fileInput = core.getInput('file').trim();
-const repoInput = core.getInput('repo').trim();
+const dockerRepoInput = (core.getInput('repo') || core.getInput('docker_repo')).trim();
 const writeRemoteCacheInput = core.getInput('write_remote_cache').trim();
 
 // Parse the action inputs.
 const tasks = tasksInput === '' ? null : tasksInput.split(/\s+/);
 const file = fileInput === '' ? null : fileInput;
-const repo = repoInput === '' ? null : repoInput;
+const dockerRepo = dockerRepoInput === '' ? null : dockerRepoInput;
 const writeRemoteCache = writeRemoteCacheInput == 'true';
 
 // Where to install Toast.
@@ -36,8 +36,8 @@ childProcess.execSync(
 // Construct the command-line arguments for Toast.
 const taskArgs = tasks === null ? [] : tasks;
 const fileArgs = file === null ? [] : ['--file', file];
-const repositoryArgs = repo === null ? [] : ['--repo', repo];
-const readRemoteCacheArgs = repo === null ? [] : ['--read-remote-cache', 'true'];
+const dockerRepoArgs = dockerRepo === null ? [] : ['--repo', dockerRepo];
+const readRemoteCacheArgs = dockerRepo === null ? [] : ['--read-remote-cache', 'true'];
 const writeRemoteCacheArgs = writeRemoteCache ? ['--write-remote-cache', 'true'] : [];
 
 // Run Toast.
@@ -45,7 +45,7 @@ try {
   childProcess.execFileSync(
     path.join(toastPrefix, 'toast'),
     fileArgs
-      .concat(repositoryArgs)
+      .concat(dockerRepoArgs)
       .concat(readRemoteCacheArgs)
       .concat(writeRemoteCacheArgs)
       .concat(taskArgs),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: ./.github/actions/toast
       with:
         tasks: build test lint release validate_release run
-        repo: stephanmisc/toast
+        docker_repo: stephanmisc/toast
         write_remote_cache: ${{ github.event_name == 'push' }}
     - run: |
         # Make Bash not silently ignore errors.
@@ -166,6 +166,6 @@ jobs:
     - uses: ./.github/actions/toast
       with:
         tasks: publish
-        repo: stephanmisc/toast
+        docker_repo: stephanmisc/toast
       env:
         CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.0] - 2021-09-23
+
+### Added
+- Added support for `--docker-cli`. This enables users to switch from Docker to Podman, if they so choose.
+
+### Changed
+- `--repo` has been renamed to `--docker-repo`. `--repo` is still supported for now, but will be removed in a future release. Please use `--docker-repo` from now on. If you are using the `repo` option for the GitHub Action, please use `docker_repo` instead.
+
 ## [0.42.1] - 2021-08-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.42.1"
+version = "0.43.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "Containerize your development and continuous integration environments."

--- a/README.md
+++ b/README.md
@@ -401,6 +401,12 @@ OPTIONS:
     -c, --config-file <PATH>
             Sets the path of the config file
 
+        --docker-cli <CLI>
+            Sets the Docker CLI binary
+
+    -r, --docker-repo <REPO>
+            Sets the Docker repository
+
     -f, --file <PATH>
             Sets the path to the toastfile
 
@@ -418,9 +424,6 @@ OPTIONS:
 
         --read-remote-cache <BOOL>
             Sets whether remote cache reading is enabled
-
-    -r, --repo <REPO>
-            Sets the Docker repository
 
     -s, --shell
             Drops you into a shell after the tasks are finished
@@ -528,7 +531,7 @@ jobs:
       with:
         file: toastfiles/toast.yml
         tasks: build lint test
-        repo: DOCKER_USERNAME/DOCKER_REPO
+        docker_repo: DOCKER_USERNAME/DOCKER_REPO
         write_remote_cache: ${{ github.event_name == 'push' }}
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,12 +60,13 @@ const READ_LOCAL_CACHE_OPTION: &str = "read-local-cache";
 const WRITE_LOCAL_CACHE_OPTION: &str = "write-local-cache";
 const READ_REMOTE_CACHE_OPTION: &str = "read-remote-cache";
 const WRITE_REMOTE_CACHE_OPTION: &str = "write-remote-cache";
-const REPO_OPTION: &str = "repo";
+const DOCKER_CLI_OPTION: &str = "docker-cli";
+const DOCKER_REPO_OPTION: &str = "docker-repo";
+const DEPRECATED_REPO_OPTION: &str = "repo";
 const LIST_OPTION: &str = "list";
 const SHELL_OPTION: &str = "shell";
 const TASKS_OPTION: &str = "tasks";
 const FORCE_OPTION: &str = "force";
-const DOCKER_CLI_OPTION: &str = "docker-cli";
 
 // Set up the logger.
 fn set_up_logging() {
@@ -213,11 +214,17 @@ fn settings() -> Result<Settings, Failure> {
                 .help("Sets whether remote cache writing is enabled"),
         )
         .arg(
-            Arg::with_name(REPO_OPTION)
+            Arg::with_name(DOCKER_REPO_OPTION)
                 .value_name("REPO")
                 .short("r")
-                .long(REPO_OPTION)
+                .long(DOCKER_REPO_OPTION)
                 .help("Sets the Docker repository"),
+        )
+        .arg(
+            Arg::with_name(DEPRECATED_REPO_OPTION)
+                .value_name("REPO")
+                .long(DEPRECATED_REPO_OPTION)
+                .help("Deprecated, use --docker-repo instead"),
         )
         .arg(
             Arg::with_name(DOCKER_CLI_OPTION)
@@ -332,7 +339,8 @@ fn settings() -> Result<Settings, Failure> {
 
     // Read the Docker repo.
     let docker_repo = matches
-        .value_of(REPO_OPTION)
+        .value_of(DOCKER_REPO_OPTION)
+        .or_else(|| matches.value_of(DEPRECATED_REPO_OPTION))
         .unwrap_or(&config.docker_repo)
         .to_owned();
 


### PR DESCRIPTION
Rename `--repo` to `--docker-repo`.

The GitHub Action now accepts `docker_repo` to match the new name of the command-line flag, but `repo` is also still supported for now to avoid breaking anyone's CI. It will be removed in a future release.

cc @kbknapp

**Status:** Ready

**Fixes:** N/A
