### PR TITLE
Drop support for `--repo` in favor of `--docker-repo`

### DIFF
--- a/.github/actions/toast/action.yml
+++ b/.github/actions/toast/action.yml
@@ -19,7 +19,8 @@ inputs:
     default: 'false'
   repo:
     description: 'Deprecated. Use `docker_repo` instead.'
-    required: false
+    required: true
+    default: ''
 runs:
   using: node12
   main: index.js

--- a/.github/actions/toast/index.js
+++ b/.github/actions/toast/index.js
@@ -6,8 +6,17 @@ const { v4: uuidv4 } = require('uuid');
 // Read the action inputs.
 const tasksInput = core.getInput('tasks').trim();
 const fileInput = core.getInput('file').trim();
-const dockerRepoInput = (core.getInput('repo') || core.getInput('docker_repo')).trim();
+const dockerRepoInput = core.getInput('docker_repo').trim();
 const writeRemoteCacheInput = core.getInput('write_remote_cache').trim();
+
+// Fail if the workflow is still using `repo` instead of `docker_repo`.
+if (core.getInput('repo').trim() !== '') {
+  console.error(
+    'Your GitHub workflow is using the legacy `repo` option in the Toast action. Please change ' +
+      'it to `docker_repo` instead. The Toast maintainers apologize for the inconvenience.'
+  );
+  process.exit(1);
+}
 
 // Parse the action inputs.
 const tasks = tasksInput === '' ? null : tasksInput.split(/\s+/);
@@ -15,7 +24,7 @@ const file = fileInput === '' ? null : fileInput;
 const dockerRepo = dockerRepoInput === '' ? null : dockerRepoInput;
 const writeRemoteCache = writeRemoteCacheInput == 'true';
 
-// Where to install Toast.
+// Where to install Toast
 const toastPrefix = process.env.HOME;
 
 // Before doing anything, disable command workflow processing. This is to prevent an injection
@@ -36,7 +45,7 @@ childProcess.execSync(
 // Construct the command-line arguments for Toast.
 const taskArgs = tasks === null ? [] : tasks;
 const fileArgs = file === null ? [] : ['--file', file];
-const dockerRepoArgs = dockerRepo === null ? [] : ['--repo', dockerRepo];
+const dockerRepoArgs = dockerRepo === null ? [] : ['--docker-repo', dockerRepo];
 const readRemoteCacheArgs = dockerRepo === null ? [] : ['--read-remote-cache', 'true'];
 const writeRemoteCacheArgs = writeRemoteCache ? ['--write-remote-cache', 'true'] : [];
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.0] - 2021-09-23
+
+### Removed
+- Removed the deprecated `--repo` flag. Please use `--docker-repo` instead.
+
 ## [0.43.0] - 2021-09-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.43.0"
+version = "0.44.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "Containerize your development and continuous integration environments."

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,6 @@ const READ_REMOTE_CACHE_OPTION: &str = "read-remote-cache";
 const WRITE_REMOTE_CACHE_OPTION: &str = "write-remote-cache";
 const DOCKER_CLI_OPTION: &str = "docker-cli";
 const DOCKER_REPO_OPTION: &str = "docker-repo";
-const DEPRECATED_REPO_OPTION: &str = "repo";
 const LIST_OPTION: &str = "list";
 const SHELL_OPTION: &str = "shell";
 const TASKS_OPTION: &str = "tasks";
@@ -221,12 +220,6 @@ fn settings() -> Result<Settings, Failure> {
                 .help("Sets the Docker repository"),
         )
         .arg(
-            Arg::with_name(DEPRECATED_REPO_OPTION)
-                .value_name("REPO")
-                .long(DEPRECATED_REPO_OPTION)
-                .help("Deprecated, use --docker-repo instead"),
-        )
-        .arg(
             Arg::with_name(DOCKER_CLI_OPTION)
                 .value_name("CLI")
                 .long(DOCKER_CLI_OPTION)
@@ -340,7 +333,6 @@ fn settings() -> Result<Settings, Failure> {
     // Read the Docker repo.
     let docker_repo = matches
         .value_of(DOCKER_REPO_OPTION)
-        .or_else(|| matches.value_of(DEPRECATED_REPO_OPTION))
         .unwrap_or(&config.docker_repo)
         .to_owned();
 


### PR DESCRIPTION
Drop support for `--repo` in favor of `--docker-repo`.

**Status:** Ready

**Fixes:** N/A
