### PR TITLE
implements ability to hide tasks from --list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.0] - 2021-09-23
+
+### Changed
+- `toast --list` now only includes tasks with a `description`. You can use this to control which tasks show up in the list.
+
 ## [0.44.0] - 2021-09-23
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.44.0"
+version = "0.45.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "Containerize your development and continuous integration environments."

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ OPTIONS:
             Prints help information
 
     -l, --list
-            Lists the tasks in the toastfile
+            Lists the tasks that have a description
 
         --read-local-cache <BOOL>
             Sets whether local cache reading is enabled

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,7 +229,7 @@ fn settings() -> Result<Settings, Failure> {
             Arg::with_name(LIST_OPTION)
                 .short("l")
                 .long(LIST_OPTION)
-                .help("Lists the tasks in the toastfile"),
+                .help("Lists the tasks in the toastfile (only tasks with a description are shown)"),
         )
         .arg(
             Arg::with_name(SHELL_OPTION)
@@ -607,10 +607,15 @@ fn entry() -> Result<(), Failure> {
 
     // If the user just wants to list all the tasks, do that and quit.
     if settings.list {
-        info!("Here are all the tasks and the environment variables they can use:");
+        info!("Here are the tasks and the environment variables they can use:");
 
         // Sort the tasks.
-        let mut task_names = toastfile.tasks.keys().collect::<Vec<_>>().clone();
+        let mut task_names: Vec<_> = toastfile
+            .tasks
+            .iter()
+            .filter(|(_, t)| t.description.is_some())
+            .map(|(k, _)| k)
+            .collect();
         task_names.sort();
 
         // Print a summary of each task.


### PR DESCRIPTION
This commit changes the behavior of `--list` by only showing tasks that
have a description (i.e. `description: string`). The help output of
`--list` is also changed to reflect this new behavior.

If a task requires a description for documentation purposes, but is not
intended to be "public" it is recommended to use a comment instead of
the `description` field.

**Status:** Ready

**Fixes:** #389 
