### PR TITLE
Add a workaround for the Docker limitation that bind mount paths must be absolute on the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.1] - 2021-11-05
+
+### Fixed
+- Added a workaround for the Docker limitation that bind mount paths must be absolute on the host. This would cause Toast to fail when using relative `mount_paths` in combination with the `-f`/`--file` flag.
+
 ## [0.45.0] - 2021-09-23
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.45.0"
+version = "0.45.1"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2021"
 description = "Containerize your development and continuous integration environments."

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -56,6 +56,10 @@ pub fn run(
     // All relative paths are relative to where the toastfile lives.
     let mut toastfile_dir = PathBuf::from(&settings.toastfile_path);
     toastfile_dir.pop();
+    if toastfile_dir.components().peekable().peek().is_none() {
+        // [ref:source_dir_nonempty]
+        toastfile_dir.push(".");
+    }
 
     // Apply defaults.
     let location = location(toastfile, task);


### PR DESCRIPTION
Add a workaround for the Docker limitation that bind mount paths must be absolute on the host.

**Status:** Ready

**Fixes:** N/A
