### PR TITLE
Fix a bug which would cause `input_paths` which correspond to files to be incorporated into the cache key even if they are denied by `excluded_input_paths`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.3] - 2022-02-09
+
+### Fixed
+- Fixed a bug which would cause `input_paths` which correspond to files to be incorporated into the cache key even if they are denied by `excluded_input_paths`.
+
 ## [0.45.2] - 2021-11-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.45.2"
+version = "0.45.3"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2021"
 description = "Containerize your development and continuous integration environments."


### PR DESCRIPTION
Fix a bug which would cause `input_paths` which correspond to files to be incorporated into the cache key even if they are denied by `excluded_input_paths`.

**Status:** Ready

**Fixes:** N/A