### PR TITLE
Fix a bug which would cause Toast to fail if the Docker image specifies a user other than `root`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.4] - 2022-05-20
+
+### Fixed
+- Fixed a bug which would cause Toast to fail if the Docker image specifies a user other than `root`.
+
 ## [0.45.3] - 2022-02-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.45.3"
+version = "0.45.4"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.45.3"
+version = "0.45.4"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2021"
 description = "Containerize your development and continuous integration environments."

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -514,6 +514,12 @@ fn container_args(
     // signal handling behavior of the child process (in our case, `/bin/sh`) works normally.
     let mut args = vec!["--init".to_owned()];
 
+    // Run as the `root` user. We always run `/bin/su` in the container, which switches to the user
+    // specified in the toastfile. We want to run `/bin/su` as root so it can switch users without
+    // requiring a password. Most Docker images already use `root` as the default user, but not
+    // all.
+    args.extend(vec!["--user".to_owned(), "root".to_owned()]);
+
     // Environment
     args.extend(
         environment.iter().flat_map(|(variable, value)| {


### PR DESCRIPTION
Fix a bug which would cause Toast to fail if the Docker image specifies a user other than `root`.

**Status:** Ready

**Fixes:** https://github.com/stepchowfun/toast/issues/420
