### PR TITLE
Add MPR installation instructions for Debian and Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,21 @@ If you're running Windows on an x86-64 CPU, download the latest binary from the 
 
 To update to an existing installation, simply replace the existing binary.
 
+### Installation on Debian or Ubuntu
+
+If you use Debian or Ubuntu, you can build and install Toast from source from the [MPR](https://mpr.makedeb.org/packages/toast). You'll need [makedeb](https://makedeb.org) installed in order to build it.
+
+```sh
+git clone 'https://mpr.makedeb.org/toast'
+cd toast/
+makedeb -si
+```
+
+Alternatively, you can set up the [Prebuilt-MPR](https://docs.makedeb.org/prebuilt-mpr/getting-started) and then install Toast directly with APT:
+
+```sh
+sudo apt install toast
+```
 
 ### Installation with Homebrew
 


### PR DESCRIPTION
This PR adds instructions for installing Toast on Debian and Ubuntu based systems via the [MPR](https://mpr.makedeb.org/packages/toast). It's a product I've personally made, but it's already gotten quite popular, and is used by a few big open-source projects already.

You can view the build file used to create the Toast package here: https://mpr.makedeb.org/pkgbase/toast/git/tree/PKGBUILD.

**Status:** Ready

**Fixes:** N/A