### PR TITLE
Fix a bug which would cause Toast to fail if `-s`/`--shell` is provided and `-f`/`--file` is set to a path with a single component (e.g., `toast.yml` rather than `./toast.yml`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.5] - 2022-07-02
+
+### Fixed
+- Fixed a bug which would cause Toast to fail if `-s`/`--shell` is provided and `-f`/`--file` is set to a path with a single component (e.g., `toast.yml` rather than `./toast.yml`).
+
 ## [0.45.4] - 2022-05-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.45.4"
+version = "0.45.5"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.45.4"
+version = "0.45.5"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2021"
 description = "Containerize your development and continuous integration environments."

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -56,10 +56,6 @@ pub fn run(
     // All relative paths are relative to where the toastfile lives.
     let mut toastfile_dir = PathBuf::from(&settings.toastfile_path);
     toastfile_dir.pop();
-    if toastfile_dir.components().peekable().peek().is_none() {
-        // [ref:source_dir_nonempty]
-        toastfile_dir.push(".");
-    }
 
     // Apply defaults.
     let location = location(toastfile, task);


### PR DESCRIPTION
Fix a bug which would cause Toast to fail if `-s`/`--shell` is provided and `-f`/`--file` is set to a path with a single component (e.g., `toast.yml` rather than `./toast.yml`).

**Status:** Ready

**Fixes:** https://github.com/stepchowfun/toast/issues/435
