### PR TITLE
Add new parameter '-o/--output-dir' which configures the export direc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,9 @@ OPTIONS:
     -l, --list
             Lists the tasks that have a description
 
+    -o, --output-dir <PATH>
+            Sets the output directory
+
         --read-local-cache <BOOL>
             Sets whether local cache reading is enabled
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,7 @@ pub struct Settings {
     spawn_shell: bool,
     tasks: Option<Vec<String>>,
     forced_tasks: Vec<String>,
-    output_path: PathBuf,
+    output_dir: PathBuf,
 }
 
 // Parse the command-line arguments.
@@ -297,7 +297,7 @@ fn settings() -> Result<Settings, Failure> {
     );
 
     // Read the config file path.
-    let output_path = matches.value_of(OUTPUT_DIR_OPTION).map_or_else(
+    let output_dir = matches.value_of(OUTPUT_DIR_OPTION).map_or_else(
         || {
             let mut candidate_dir = toastfile_path.clone();
             candidate_dir.pop();
@@ -397,7 +397,7 @@ fn settings() -> Result<Settings, Failure> {
         spawn_shell,
         tasks,
         forced_tasks,
-        output_path,
+        output_dir,
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,10 +301,10 @@ fn settings() -> Result<Settings, Failure> {
         || {
             let mut candidate_dir = toastfile_path.clone();
             candidate_dir.pop();
-            Ok(candidate_dir)
+            candidate_dir
         },
-        |path| Ok(PathBuf::from(path)),
-    )?;
+        |path| PathBuf::new(path).to_owned(),
+    );
 
     // Parse the config file.
     let config_data = config_file_path

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,22 +297,14 @@ fn settings() -> Result<Settings, Failure> {
     );
 
     // Read the config file path.
-    let default_output_path = toastfile_path.parent().unwrap().to_path_buf();
     let output_path = matches.value_of(OUTPUT_DIR_OPTION).map_or_else(
-        || Ok(default_output_path),
+        || {
+            let mut candidate_dir = toastfile_path.to_path_buf();
+            candidate_dir.pop();
+            return Ok(candidate_dir);
+        },
         |path| {
-            let candidate_path = PathBuf::from(path);
-            return if candidate_path.exists() && candidate_path.is_dir() {
-                Ok(candidate_path)
-            } else {
-                Err(Failure::User(
-                    format!(
-                        "Output Path {} not exist.",
-                        path,
-                    ),
-                    None,
-                ))
-            }
+            return Ok(PathBuf::from(path));
         },
     )?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,6 @@ const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Info;
 // Command-line argument and option names
 const TOASTFILE_OPTION: &str = "file";
 const CONFIG_FILE_OPTION: &str = "config-file";
-const CONFIG_OUTPUT_DIR_OPTION: &str = "output-dir";
 const READ_LOCAL_CACHE_OPTION: &str = "read-local-cache";
 const WRITE_LOCAL_CACHE_OPTION: &str = "write-local-cache";
 const READ_REMOTE_CACHE_OPTION: &str = "read-remote-cache";
@@ -69,6 +68,7 @@ const LIST_OPTION: &str = "list";
 const SHELL_OPTION: &str = "shell";
 const TASKS_OPTION: &str = "tasks";
 const FORCE_OPTION: &str = "force";
+const OUTPUT_DIR_OPTION: &str = "output-dir";
 
 // Set up the logger.
 fn set_up_logging() {
@@ -193,10 +193,10 @@ fn settings() -> Result<Settings, Failure> {
                 .help("Sets the path of the config file"),
         )
         .arg(
-            Arg::with_name(CONFIG_OUTPUT_DIR_OPTION)
+            Arg::with_name(OUTPUT_DIR_OPTION)
                 .value_name("PATH")
                 .short("o")
-                .long(CONFIG_OUTPUT_DIR_OPTION)
+                .long(OUTPUT_DIR_OPTION)
                 .help("Sets the output directory"),
         )
         .arg(
@@ -298,7 +298,7 @@ fn settings() -> Result<Settings, Failure> {
 
     // Read the config file path.
     let default_output_path = toastfile_path.parent().unwrap().to_path_buf();
-    let output_path = matches.value_of(CONFIG_OUTPUT_DIR_OPTION).map_or_else(
+    let output_path = matches.value_of(OUTPUT_DIR_OPTION).map_or_else(
         || Ok(default_output_path),
         |path| {
             let candidate_path = PathBuf::from(path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -299,13 +299,11 @@ fn settings() -> Result<Settings, Failure> {
     // Read the config file path.
     let output_path = matches.value_of(OUTPUT_DIR_OPTION).map_or_else(
         || {
-            let mut candidate_dir = toastfile_path.to_path_buf();
+            let mut candidate_dir = toastfile_path.clone();
             candidate_dir.pop();
-            return Ok(candidate_dir);
+            Ok(candidate_dir)
         },
-        |path| {
-            return Ok(PathBuf::from(path));
-        },
+        |path| Ok(PathBuf::from(path)),
     )?;
 
     // Parse the config file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,7 +303,7 @@ fn settings() -> Result<Settings, Failure> {
             candidate_dir.pop();
             candidate_dir
         },
-        |path| PathBuf::new(path).to_owned(),
+        |path| Path::new(path).to_owned(),
     );
 
     // Parse the config file.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -57,6 +57,8 @@ pub fn run(
     let mut toastfile_dir = PathBuf::from(&settings.toastfile_path);
     toastfile_dir.pop();
 
+    let output_dir = PathBuf::from(&settings.output_path);
+
     // Apply defaults.
     let location = location(toastfile, task);
     let user = user(toastfile, task);
@@ -182,7 +184,7 @@ pub fn run(
                 &container,
                 &task.output_paths,
                 &location,
-                &toastfile_dir,
+                &output_dir,
                 interrupted,
             ) {
                 return (Err(e), Some(context));
@@ -282,7 +284,7 @@ pub fn run(
                     &container,
                     &task.output_paths,
                     &location,
-                    &toastfile_dir,
+                    &output_dir,
                     interrupted,
                 ) {
                     return (Err(e), Some(context));
@@ -294,7 +296,7 @@ pub fn run(
                     &container,
                     &task.output_paths_on_failure,
                     &location,
-                    &toastfile_dir,
+                    &output_dir,
                     interrupted,
                 ) {
                     return (Err(e), Some(context));

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -57,7 +57,7 @@ pub fn run(
     let mut toastfile_dir = PathBuf::from(&settings.toastfile_path);
     toastfile_dir.pop();
 
-    let output_dir = PathBuf::from(&settings.output_dir);;
+    let output_dir = &settings.output_dir;
 
     // Apply defaults.
     let location = location(toastfile, task);
@@ -184,7 +184,7 @@ pub fn run(
                 &container,
                 &task.output_paths,
                 &location,
-                &output_dir,
+                output_dir,
                 interrupted,
             ) {
                 return (Err(e), Some(context));
@@ -284,7 +284,7 @@ pub fn run(
                     &container,
                     &task.output_paths,
                     &location,
-                    &output_dir,
+                    output_dir,
                     interrupted,
                 ) {
                     return (Err(e), Some(context));
@@ -296,7 +296,7 @@ pub fn run(
                     &container,
                     &task.output_paths_on_failure,
                     &location,
-                    &output_dir,
+                    output_dir,
                     interrupted,
                 ) {
                     return (Err(e), Some(context));

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -57,7 +57,7 @@ pub fn run(
     let mut toastfile_dir = PathBuf::from(&settings.toastfile_path);
     toastfile_dir.pop();
 
-    let output_dir = PathBuf::from(&settings.output_path);
+    let output_dir = PathBuf::from(&settings.output_dir);;
 
     // Apply defaults.
     let location = location(toastfile, task);


### PR DESCRIPTION
This PR adds a new parameter **-o/--output-dir** which allows configuring the export directory where to copy in data configured with **output_paths**.

**Status:** Ready 

