### PR TITLE
Make `mount_paths` work on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.46.1] - 2023-03-02
+
+### Fixed
+- `mount_paths` now works on Windows.
+
 ## [0.46.0] - 2023-02-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.46.0"
+version = "0.46.1"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2021"
 description = "Containerize your development and continuous integration environments."


### PR DESCRIPTION
Make `mount_paths` work on Windows.

**Status:** Ready

**Fixes:** https://github.com/stepchowfun/toast/issues/456
