### PR TITLE
Fix container_path for mounting to use Unix-like path separator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +649,7 @@ dependencies = [
  "indicatif",
  "lazy_static",
  "log",
+ "path-slash",
  "scopeguard",
  "serde",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ sha2 = "0.9"
 tar = "0.4"
 tempfile = "3"
 walkdir = "2"
+path-slash = "0.2.1"
 
 [dependencies.clap]
 version = "2"

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,5 +1,6 @@
 use {
     crate::{failure, failure::Failure, format::CodeStr, spinner::spin, toastfile::MappingPath},
+    path_slash::PathBufExt,
     std::{
         collections::HashMap,
         env::current_dir,
@@ -555,7 +556,7 @@ fn container_args(
                     absolute_source_dir
                         .join(&mount_path.host_path)
                         .to_string_lossy(),
-                    location.join(&mount_path.container_path).to_string_lossy(),
+                    location.join(&mount_path.container_path).to_slash_lossy(),
                 )
             } else {
                 format!(
@@ -563,7 +564,7 @@ fn container_args(
                     absolute_source_dir
                         .join(&mount_path.host_path)
                         .to_string_lossy(),
-                    location.join(&mount_path.container_path).to_string_lossy(),
+                    location.join(&mount_path.container_path).to_slash_lossy(),
                 )
             },
         ]


### PR DESCRIPTION
This PR fixes a problem with container mount path on Windows. 
Currently this path will be created over pathbuf implementation which creates a OS like path. On Windows this path would result in a mixture of Windows and Unix-Like separators  (i.e. **/scratch\my_data**) which not results in a mount under folder **/scratch** but as **/scratch\my_data**.

The function **to_slash_lossy** from crate **path-slash** convert container_path explicitly to Unix-Like because currently only Linux containers are supported.

Status: Ready