### PR TITLE
Add new parameter '--force-image-pull' which force pull image from re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,9 @@ OPTIONS:
         --force <TASK>...
             Runs a task unconditionally, even if it’s cached
 
+        --force-image-pull
+            Pulls the base image unconditionally, even if it already exists locally
+
     -h, --help
             Prints help information
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ const LIST_OPTION: &str = "list";
 const SHELL_OPTION: &str = "shell";
 const TASKS_OPTION: &str = "tasks";
 const FORCE_OPTION: &str = "force";
+const FORCE_IMAGE_PULL: &str = "force-image-pull";
 const OUTPUT_DIR_OPTION: &str = "output-dir";
 
 // Set up the logger.
@@ -165,6 +166,7 @@ pub struct Settings {
     spawn_shell: bool,
     tasks: Option<Vec<String>>,
     forced_tasks: Vec<String>,
+    force_image_pull: bool,
     output_dir: PathBuf,
 }
 
@@ -255,6 +257,11 @@ fn settings() -> Result<Settings, Failure> {
                 .long(FORCE_OPTION)
                 .help("Runs a task unconditionally, even if it\u{2019}s cached")
                 .multiple(true),
+        )
+        .arg(
+            Arg::with_name(FORCE_IMAGE_PULL)
+                .long(FORCE_IMAGE_PULL)
+                .help("Pulls the base image unconditionally, even if it already exists locally"),
         )
         .arg(
             Arg::with_name(TASKS_OPTION)
@@ -386,6 +393,9 @@ fn settings() -> Result<Settings, Failure> {
                 .collect::<Vec<_>>()
         });
 
+    // Read the force image pulling switch.
+    let force_image_pull = matches.is_present(FORCE_IMAGE_PULL);
+
     Ok(Settings {
         toastfile_path,
         docker_cli,
@@ -398,6 +408,7 @@ fn settings() -> Result<Settings, Failure> {
         spawn_shell,
         tasks,
         forced_tasks,
+        force_image_pull,
         output_dir,
     })
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -206,12 +206,13 @@ pub fn run(
             }),
         )
     } else {
-        // Pull the image if necessary. Note that this is not considered reading from the remote
-        // cache.
-        if !match docker::image_exists(&settings.docker_cli, &context.image, interrupted) {
-            Ok(exists) => exists,
-            Err(e) => return (Err(e), Some(context)),
-        } {
+        // Pull the image if necessary. Force reading from the remote if configured
+        if settings.force_image_pull
+            || !match docker::image_exists(&settings.docker_cli, &context.image, interrupted) {
+                Ok(exists) => exists,
+                Err(e) => return (Err(e), Some(context)),
+            }
+        {
             if let Err(e) = docker::pull_image(&settings.docker_cli, &context.image, interrupted) {
                 return (Err(e), Some(context));
             }


### PR DESCRIPTION
Hi @stepchowfun I have a feature-PR which adds a new parameter **--force-image-pull** to force pull image from repository. 

Currently toast only downloads requested image from repository if it not exists locally. Some images are updating remotely with same name (e.g. latest) and so a extra **docker pull** would be needed before running toast to get the newest version. 
If this new argument use used, toast will always call a **docker pull** before creating the container.

**Status:** Ready
