### PR TITLE
Fix a bug in `--force-image-pull` which would cause the flag to have no effect if the first task in the schedule is available in the local or remote cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.47.1] - 2023-04-03
+
+### Added
+- Fixed a bug in `--force-image-pull` which would cause the flag to have no effect if the first task in the schedule is available in the local or remote cache. Also, the flag has been renamed to `--force-all`.
+
 ## [0.47.0] - 2023-04-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.47.0"
+version = "0.47.1"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2021"
 description = "Containerize your development and continuous integration environments."

--- a/README.md
+++ b/README.md
@@ -413,8 +413,8 @@ OPTIONS:
         --force <TASK>...
             Runs a task unconditionally, even if it’s cached
 
-        --force-image-pull
-            Pulls the base image unconditionally, even if it already exists locally
+        --force-all
+            Pulls the base image and runs all tasks unconditionally
 
     -h, --help
             Prints help information

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -50,6 +50,7 @@ pub fn run(
     toastfile: &Toastfile,
     task: &Task,
     caching_enabled: bool,
+    force_pull: bool,
     context: Context,
     need_context: bool,
 ) -> (Result<(), Failure>, Option<Context>) {
@@ -206,8 +207,8 @@ pub fn run(
             }),
         )
     } else {
-        // Pull the image if necessary. Force reading from the remote if configured
-        if settings.force_image_pull
+        // Pull the image if necessary. Force reading from the remote if configured.
+        if force_pull
             || !match docker::image_exists(&settings.docker_cli, &context.image, interrupted) {
                 Ok(exists) => exists,
                 Err(e) => return (Err(e), Some(context)),


### PR DESCRIPTION
Fix a bug in `--force-image-pull` which would cause the flag to have no effect if the first task in the schedule is available in the local or remote cache.

Also, the flag has been renamed to `--force-all`.

@raennor if you've already updated to v0.47.0 for the new `--force-image-pull` flag, you'll want to update again to v0.47.1 to get this fix.

**Status:** Ready

**Fixes:** N/A