### PR TITLE
Respect `--shell` when a task fails due to `output_paths` not existing in the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.47.6] - 2024-02-21
+
+### Fixed
+- When a task fails due to `output_paths` not existing in the container, the `--shell` flag is no longer ignored.
+
 ## [0.47.5] - 2023-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "toast"
-version = "0.47.5"
+version = "0.47.6"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast"
-version = "0.47.5"
+version = "0.47.6"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2021"
 description = "Containerize your development and continuous integration environments."

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -274,7 +274,7 @@ pub fn run(
             .map_err(|e| match e {
                 Failure::Interrupted => e,
                 Failure::System(_, _) | Failure::User(_, _) => {
-                    Failure::User("Command failed.".to_owned(), None)
+                    Failure::User("Task failed.".to_owned(), None)
                 }
             });
 


### PR DESCRIPTION
Respect `--shell` when a task fails due to `output_paths` not existing in the container.

**Status:** Ready

**Fixes:** N/A