### PR TITLE
fix: eliminate needless lifetimes

### DIFF
--- a/src/failure.rs
+++ b/src/failure.rs
@@ -24,7 +24,7 @@ impl fmt::Display for Failure {
 }
 
 impl error::Error for Failure {
-    fn source<'a>(&'a self) -> Option<&'a (dyn error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Self::System(_, source) => source.as_ref().map(|e| &**e),
             Self::User(_, source) => source.as_ref().map(|e| &**e),


### PR DESCRIPTION
seeing some regression build issue against rust 1.83.0 as 

```
error: elided lifetime has a name
  --> src/failure.rs:27:39
   |
27 |     fn source<'a>(&'a self) -> Option<&(dyn error::Error + 'static)> {
   |               --                      ^ this elided lifetime gets resolved as `'a`
   |               |
   |               lifetime `'a` declared here
   |
   = note: `-D elided-named-lifetimes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(elided_named_lifetimes)]`
```

**Status:** Ready

relates to https://github.com/Homebrew/homebrew-core/pull/199379
