### PR TITLE
Rebuild bundled action node_modules

### DIFF
--- a/.github/actions/toast/node_modules/.bin/uuid 2
+++ b/.github/actions/toast/node_modules/.bin/uuid 2
@@ -1,1 +1,0 @@
-../uuid/dist/bin/uuid


### PR DESCRIPTION
## Summary
- remove the stale vendored `node_modules` tree for the bundled GitHub Action
- recreate it from the current lockfile with `npm ci`
- drop the orphaned `.github/actions/toast/node_modules/.bin/uuid 2` symlink that breaks action staging

## Validation
- `rm -rf .github/actions/toast/node_modules`
- `npm ci` in `.github/actions/toast`