### PR TITLE
Migrate to yaml_serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,19 +813,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,12 +910,12 @@ dependencies = [
  "log",
  "scopeguard",
  "serde",
- "serde_yaml",
  "sha2",
  "tar",
  "tempfile",
  "typed-path",
  "walkdir",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -960,12 +953,6 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"
@@ -1222,6 +1209,19 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ indicatif = "0.18"
 log = "0.4"
 scopeguard = "1"
 serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.9"
+yaml_serde = "0.10"
 sha2 = "0.11"
 tar = "0.4"
 tempfile = "3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,7 @@ fn default_write_remote_cache() -> bool {
 
 // Parse a program configuration.
 pub fn parse(config: &str) -> Result<Config, Failure> {
-    serde_yaml::from_str(config).map_err(failure::user("Syntax error."))
+    yaml_serde::from_str(config).map_err(failure::user("Syntax error."))
 }
 
 #[cfg(test)]

--- a/src/toastfile.rs
+++ b/src/toastfile.rs
@@ -238,7 +238,7 @@ fn default_user() -> String {
 pub fn parse(toastfile_data: &str) -> Result<Toastfile, Failure> {
     // Deserialize the data.
     let toastfile: Toastfile =
-        serde_yaml::from_str(toastfile_data).map_err(|e| Failure::User(format!("{e}"), None))?;
+        yaml_serde::from_str(toastfile_data).map_err(|e| Failure::User(format!("{e}"), None))?;
 
     // Make sure the dependencies are valid.
     check_dependencies(&toastfile)?;


### PR DESCRIPTION
Migrate from the deprecated, unmaintained `serde_yaml` crate to the maintained `yaml_serde` fork. Update the YAML call sites and lockfile accordingly.

**Status:** Ready

**Fixes:** N/A