### PR TITLE
Install the latest release by default

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,8 +30,7 @@ The GitHub workflow will fail initially because the jobs which test the installe
 
 ### Release instructions
 
-Releasing a new version is a three-step process:
+Releasing a new version is a two-step process:
 
-1. Bump the version in `[file:Cargo.toml]`, run `cargo build` to update `[file:Cargo.lock]`, and update `[file:CHANGELOG.md]` with information about the new version. Ship those changes as a single commit.
-2. Once the GitHub workflow has finished on the `main` branch, update the version in `[file:install.sh]` to point to the new release.
-3. Create a pull request in the `Homebrew/homebrew-core` repository on GitHub to bump the version in [this file](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/t/toast.rb).
+1. Bump the version in `[file:Cargo.toml]`, run `cargo build` to update `[file:Cargo.lock]`, and update `[file:CHANGELOG.md]` with information about the new version. Ship those changes as a single commit. Once the GitHub workflow publishes the release, the installation script will begin installing it by default.
+2. Create a pull request in the `Homebrew/homebrew-core` repository on GitHub to bump the version in [this file](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/t/toast.rb).

--- a/install.sh
+++ b/install.sh
@@ -13,9 +13,6 @@
   # Where the binary will be installed
   DESTINATION="${PREFIX:-/usr/local/bin}/toast"
 
-  # Which version to download
-  RELEASE="v${VERSION:-0.48.0}"
-
   # Determine which binary to download.
   FILENAME=''
   if uname -a | grep -qi 'x86_64.*GNU/Linux'; then
@@ -56,10 +53,15 @@
   # Compute the full file path.
   SOURCE="$TEMPDIR/$FILENAME"
 
+  # Download the requested version, or the latest published version by default.
+  if [ -n "${VERSION:-}" ]; then
+    DOWNLOAD_URL="https://github.com/stepchowfun/toast/releases/download/v$VERSION/$FILENAME"
+  else
+    DOWNLOAD_URL="https://github.com/stepchowfun/toast/releases/latest/download/$FILENAME"
+  fi
+
   # Download the binary.
-  curl \
-    "https://github.com/stepchowfun/toast/releases/download/$RELEASE/$FILENAME" \
-    -o "$SOURCE" -LSf || fail 'There was an error downloading the binary.'
+  curl "$DOWNLOAD_URL" -o "$SOURCE" -LSf || fail 'There was an error downloading the binary.'
 
   # Make it executable.
   chmod a+x "$SOURCE" || fail 'There was an error setting the permissions for the binary.'


### PR DESCRIPTION
Use the latest published GitHub release when `VERSION` is not set, while preserving explicit version selection with `VERSION=x.y.z`. This removes the follow-up installer bump from the release process.

**Status:** Ready

**Fixes:** N/A
